### PR TITLE
Add PageTabView underline indicator

### DIFF
--- a/LineSDK/LineSDK.xcodeproj/project.pbxproj
+++ b/LineSDK/LineSDK.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		D17C6FB022237CB1007BA517 /* ResultUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17C6FAF22237CB1007BA517 /* ResultUtilsTests.swift */; };
 		D1A591272139489E00AC080D /* JWK.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A591262139489E00AC080D /* JWK.swift */; };
 		D1A591292139495B00AC080D /* JWKSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A591282139495B00AC080D /* JWKSet.swift */; };
+		DB0AFF612247FB2E002729AD /* PageTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0AFF602247FB2E002729AD /* PageTabViewTests.swift */; };
 		DBDCFD322126BD7200E8327A /* GetApproversInFriendsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */; };
 		DBDCFD342126CB6300E8327A /* GetApproversInFriendsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */; };
 		DBE4E36D211D6C1A00184D66 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE4E36C211D6C1A00184D66 /* User.swift */; };
@@ -514,6 +515,7 @@
 		D17C6FAF22237CB1007BA517 /* ResultUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultUtilsTests.swift; sourceTree = "<group>"; };
 		D1A591262139489E00AC080D /* JWK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWK.swift; sourceTree = "<group>"; };
 		D1A591282139495B00AC080D /* JWKSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKSet.swift; sourceTree = "<group>"; };
+		DB0AFF602247FB2E002729AD /* PageTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTabViewTests.swift; sourceTree = "<group>"; };
 		DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsRequest.swift; sourceTree = "<group>"; };
 		DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsTests.swift; sourceTree = "<group>"; };
 		DBE4E36C211D6C1A00184D66 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -789,6 +791,7 @@
 		4B90588521006E5D004D717F /* LineSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				DB0AFF5F2247FB06002729AD /* UI */,
 				4B15EEF9211D5BE800866E6C /* Message */,
 				4B792FB421103CFD00EDDD1E /* API */,
 				4B8A9655211009A400760219 /* Login */,
@@ -1258,6 +1261,14 @@
 			path = JWK;
 			sourceTree = "<group>";
 		};
+		DB0AFF5F2247FB06002729AD /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				DB0AFF602247FB2E002729AD /* PageTabViewTests.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
 		DBE4E36E211D6C2600184D66 /* Graph */ = {
 			isa = PBXGroup;
 			children = (
@@ -1625,6 +1636,7 @@
 				4BA8E44E210EE79B00355F03 /* PipelineTests.swift in Sources */,
 				4B8FF4932105C49200890AEF /* LoginFlowTests.swift in Sources */,
 				4B792FB621103D2200EDDD1E /* PostOTPRequestTests.swift in Sources */,
+				DB0AFF612247FB2E002729AD /* PageTabViewTests.swift in Sources */,
 				4B9A303D2121238D00174C6F /* AudioMessageTests.swift in Sources */,
 				4BF53380222E3DB80080D138 /* ChainedPaginatedRequestsTests.swift in Sources */,
 				4B8A965721100A5800760219 /* LoginConfigurationTests.swift in Sources */,

--- a/LineSDK/LineSDK/SharingUI/PageTabView.swift
+++ b/LineSDK/LineSDK/SharingUI/PageTabView.swift
@@ -64,12 +64,13 @@ class PageTabView: UIView {
 
         enum Design {
             static let height: CGFloat = 3
-            static let widthMargin: CGFloat = 2
+            static let widthMargin: CGFloat = 4
+            static func color() -> UIColor { return .black }
         }
 
         private let underline: UIView = {
             let underline = UIView()
-            underline.backgroundColor = .black
+            underline.backgroundColor = Design.color()
             return underline
         }()
 
@@ -84,7 +85,7 @@ class PageTabView: UIView {
         }
 
         func setup(centerX: CGFloat, width: CGFloat) {
-            underline.bounds.size = CGSize(width: width + 2 * Underline.Design.widthMargin,
+            underline.bounds.size = CGSize(width: width + Design.widthMargin,
                                            height: Design.height)
             underline.center = CGPoint(x: centerX, y: bounds.midY)
         }

--- a/LineSDK/LineSDK/SharingUI/PageTabView.swift
+++ b/LineSDK/LineSDK/SharingUI/PageTabView.swift
@@ -194,6 +194,11 @@ class PageTabView: UIView {
     }
 
     @objc func tabViewTouchUpInside(_ sender: TabView) {
+        self.isUserInteractionEnabled = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.isUserInteractionEnabled = true
+        }
+
         selectIndex(sender.index)
     }
 

--- a/LineSDK/LineSDK/SharingUI/PageViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/PageViewController.swift
@@ -31,34 +31,13 @@ class PageViewController: UIViewController {
     private lazy var pageContainerView: UIView = {
         let pageContainerView = UIView()
         view.addSubview(pageContainerView)
-
-        pageContainerView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            pageContainerView.topAnchor     .constraint(equalTo: pageTabView.bottomAnchor),
-            pageContainerView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
-            pageContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            pageContainerView.bottomAnchor  .constraint(equalTo: view.bottomAnchor)
-        ])
-
         return pageContainerView
     }()
 
     private lazy var pageTabView: PageTabView = {
         let pageTabView = PageTabView(titles: pages.map { $0.title })
         view.addSubview(pageTabView)
-
-        pageTabView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            pageTabView.heightAnchor  .constraint(equalToConstant: 45),
-            pageTabView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
-            pageTabView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            pageTabView.topAnchor     .constraint(equalTo: safeTopAnchor)
-        ])
-
         pageTabView.delegate = self
-
         return pageTabView
     }()
 
@@ -90,6 +69,30 @@ class PageViewController: UIViewController {
 
         view.backgroundColor = .white
         pageTabView.backgroundColor = .yellow
+
+        view.addSubview(pageTabView)
+        view.addSubview(pageContainerView)
+
+        pageTabView.translatesAutoresizingMaskIntoConstraints = false
+        pageContainerView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            pageTabView.heightAnchor  .constraint(equalToConstant: 45),
+            pageTabView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
+            pageTabView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pageTabView.topAnchor     .constraint(equalTo: safeTopAnchor)
+            ])
+
+        NSLayoutConstraint.activate([
+            pageContainerView.topAnchor     .constraint(equalTo: pageTabView.bottomAnchor),
+            pageContainerView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
+            pageContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pageContainerView.bottomAnchor  .constraint(equalTo: view.bottomAnchor)
+            ])
+
+        view.layoutIfNeeded()
+        pageTabView.resetUnderline()
+
 
         pageScrollViewObserver = pageScrollView?.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, change in
             guard let self = self else { return }

--- a/LineSDK/LineSDK/SharingUI/PageViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/PageViewController.swift
@@ -28,7 +28,7 @@ class PageViewController: UIViewController {
         let title: String
     }
 
-    private lazy var pageContainerView: UIView! = {
+    private lazy var pageContainerView: UIView = {
         let pageContainerView = UIView()
         view.addSubview(pageContainerView)
 
@@ -44,7 +44,7 @@ class PageViewController: UIViewController {
         return pageContainerView
     }()
 
-    private lazy var pageTabView: PageTabView! = {
+    private lazy var pageTabView: PageTabView = {
         let pageTabView = PageTabView(titles: pages.map { $0.title })
         view.addSubview(pageTabView)
 
@@ -64,12 +64,12 @@ class PageViewController: UIViewController {
 
     let pages: [Page]
 
-    private lazy var pageViewController: UIPageViewController! = {
+    private lazy var pageViewController: UIPageViewController = {
         return UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
     }()
 
-    private lazy var pageScrollView: UIScrollView! = {
-        return (pageViewController.view.subviews.first { $0 is UIScrollView }) as! UIScrollView
+    private lazy var pageScrollView: UIScrollView? = {
+        return (pageViewController.view.subviews.first { $0 is UIScrollView }) as? UIScrollView
     }()
 
     private var pageScrollViewObserver: NSKeyValueObservation?
@@ -91,7 +91,7 @@ class PageViewController: UIViewController {
         view.backgroundColor = .white
         pageTabView.backgroundColor = .yellow
 
-        pageScrollViewObserver = pageScrollView.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, change in
+        pageScrollViewObserver = pageScrollView?.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, change in
             guard let self = self else { return }
             guard let newValue = change.newValue else { return }
             let width = self.pageViewController.view.bounds.width
@@ -99,7 +99,7 @@ class PageViewController: UIViewController {
             self.pageTabView.updateScrollingProgress(progress)
         }
 
-        pageScrollView.delegate = self
+        pageScrollView?.delegate = self
     }
 
     private func setupPageViewController() {

--- a/LineSDK/LineSDK/SharingUI/PageViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/PageViewController.swift
@@ -31,13 +31,29 @@ class PageViewController: UIViewController {
     private lazy var pageContainerView: UIView = {
         let pageContainerView = UIView()
         view.addSubview(pageContainerView)
+        pageContainerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            pageContainerView.topAnchor     .constraint(equalTo: pageTabView.bottomAnchor),
+            pageContainerView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
+            pageContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pageContainerView.bottomAnchor  .constraint(equalTo: view.bottomAnchor)
+            ])
+
         return pageContainerView
     }()
 
     private lazy var pageTabView: PageTabView = {
         let pageTabView = PageTabView(titles: pages.map { $0.title })
         view.addSubview(pageTabView)
+        pageTabView.translatesAutoresizingMaskIntoConstraints = false
         pageTabView.delegate = self
+        NSLayoutConstraint.activate([
+            pageTabView.heightAnchor  .constraint(equalToConstant: 45),
+            pageTabView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
+            pageTabView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pageTabView.topAnchor     .constraint(equalTo: safeTopAnchor)
+            ])
+
         return pageTabView
     }()
 
@@ -66,33 +82,10 @@ class PageViewController: UIViewController {
         super.viewDidLoad()
 
         setupPageViewController()
+        setupSubviews()
 
         view.backgroundColor = .white
         pageTabView.backgroundColor = .yellow
-
-        view.addSubview(pageTabView)
-        view.addSubview(pageContainerView)
-
-        pageTabView.translatesAutoresizingMaskIntoConstraints = false
-        pageContainerView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            pageTabView.heightAnchor  .constraint(equalToConstant: 45),
-            pageTabView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
-            pageTabView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            pageTabView.topAnchor     .constraint(equalTo: safeTopAnchor)
-            ])
-
-        NSLayoutConstraint.activate([
-            pageContainerView.topAnchor     .constraint(equalTo: pageTabView.bottomAnchor),
-            pageContainerView.leadingAnchor .constraint(equalTo: view.leadingAnchor),
-            pageContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            pageContainerView.bottomAnchor  .constraint(equalTo: view.bottomAnchor)
-            ])
-
-        view.layoutIfNeeded()
-        pageTabView.resetUnderline()
-
 
         pageScrollViewObserver = pageScrollView?.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, change in
             guard let self = self else { return }
@@ -103,6 +96,13 @@ class PageViewController: UIViewController {
         }
 
         pageScrollView?.delegate = self
+    }
+
+    private func setupSubviews() {
+        _ = pageContainerView
+        _ = pageTabView
+        view.layoutIfNeeded()
+        pageTabView.resetUnderline()
     }
 
     private func setupPageViewController() {

--- a/LineSDK/LineSDK/SharingUI/ShareViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareViewController.swift
@@ -26,15 +26,22 @@ public class ShareViewController: UINavigationController {
     public init() {
         let v1 = UIViewController()
         v1.view.backgroundColor = .red
-        let page1 = PageViewController.Page(viewController: v1, title: "V1")
+        let page1 = PageViewController.Page(viewController: v1, title: "A")
         let v2 = UIViewController()
         v2.view.backgroundColor = .yellow
-        let page2 = PageViewController.Page(viewController: v2, title: "V2")
+        let page2 = PageViewController.Page(viewController: v2, title: "BB")
         let v3 = UIViewController()
         v3.view.backgroundColor = .blue
-        let page3 = PageViewController.Page(viewController: v3, title: "V3")
+        let page3 = PageViewController.Page(viewController: v3, title: "CCC")
 
         let root = PageViewController(pages: [page1, page2, page3])
+        root.pages.forEach { page in
+            let label = UILabel()
+            label.text = page.title
+            label.sizeToFit()
+            label.center = page.viewController.view.center
+            page.viewController.view.addSubview(label)
+        }
         super.init(rootViewController: root)
     }
 

--- a/LineSDK/LineSDKTests/UI/PageTabViewTests.swift
+++ b/LineSDK/LineSDKTests/UI/PageTabViewTests.swift
@@ -1,0 +1,47 @@
+//
+//  PageTabViewTests.swift
+//
+//  Copyright (c) 2016-present, LINE Corporation. All rights reserved.
+//
+//  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+//  copy and distribute this software in source code or binary form for use
+//  in connection with the web services and APIs provided by LINE Corporation.
+//
+//  As with any software that integrates with the LINE Corporation platform, your use of this software
+//  is subject to the LINE Developers Agreement [http://terms2.line.me/LINE_Developers_Agreement].
+//  This copyright notice shall be included in all copies or substantial portions of the software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import XCTest
+@testable import LineSDK
+
+class PageTabViewTests: XCTestCase {
+
+    func testUnderlineWidth() {
+        let titleWidths: [CGFloat] = [20,40,60]
+
+        // test leftmost
+        XCTAssertEqual(20, PageTabView.Underline.preferredWidth(progress: -0.1, titleWidths: titleWidths))
+
+        // test rightmost
+        XCTAssertEqual(60, PageTabView.Underline.preferredWidth(progress: 2.1, titleWidths: titleWidths))
+
+        // test middle
+        XCTAssertEqual(40, PageTabView.Underline.preferredWidth(progress: 1, titleWidths: titleWidths))
+
+        // test left half
+        var w: CGFloat = 0.9 * 20 + 0.1 * 40
+        XCTAssertEqual(w, PageTabView.Underline.preferredWidth(progress: 0.1, titleWidths: titleWidths))
+
+        // test right half
+        w = 0.8 * 40 + 0.2 * 60
+        XCTAssertEqual(w, PageTabView.Underline.preferredWidth(progress: 1.2, titleWidths: titleWidths))
+    }
+}


### PR DESCRIPTION
## About
- Add underline indicator animation at the bottom of PageTabView to indicate the current selected tab
- The UIPageViewController `contentOffset` pattern will be reset, ex: `0->375->750->375->0`,
thus use a `currentProgress` and `currentDiff` to normalized it