### PR TITLE
Preparation for selected panel

### DIFF
--- a/LineSDK/LineSDK.xcodeproj/project.pbxproj
+++ b/LineSDK/LineSDK.xcodeproj/project.pbxproj
@@ -231,7 +231,7 @@
 		4BFC09F5213CF5B200F4594D /* GetDiscoveryDocumentRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFC09F4213CF5B200F4594D /* GetDiscoveryDocumentRequestTests.swift */; };
 		4BFC09F7213CF68000F4594D /* GetJWKSetRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFC09F6213CF68000F4594D /* GetJWKSetRequest.swift */; };
 		4BFC09F9213CFB6000F4594D /* GetJWKSetRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFC09F8213CFB6000F4594D /* GetJWKSetRequestTests.swift */; };
-		4BFCD204224CAF6100CD9544 /* ShareTargetSearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFCD203224CAF6100CD9544 /* ShareTargetSearchResultViewController.swift */; };
+		4BFCD204224CAF6100CD9544 /* ShareTargetSearchResultTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFCD203224CAF6100CD9544 /* ShareTargetSearchResultTableViewController.swift */; };
 		4BFD605A212A875F009E9838 /* FlexBoxComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFD6059212A875F009E9838 /* FlexBoxComponent.swift */; };
 		4BFD605C212A8775009E9838 /* FlexTextComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFD605B212A8775009E9838 /* FlexTextComponent.swift */; };
 		4BFD605E212A8BA6009E9838 /* FlexComponentMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFD605D212A8BA6009E9838 /* FlexComponentMessageTests.swift */; };
@@ -524,7 +524,7 @@
 		4BFC09F4213CF5B200F4594D /* GetDiscoveryDocumentRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDiscoveryDocumentRequestTests.swift; sourceTree = "<group>"; };
 		4BFC09F6213CF68000F4594D /* GetJWKSetRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetJWKSetRequest.swift; sourceTree = "<group>"; };
 		4BFC09F8213CFB6000F4594D /* GetJWKSetRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetJWKSetRequestTests.swift; sourceTree = "<group>"; };
-		4BFCD203224CAF6100CD9544 /* ShareTargetSearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTargetSearchResultViewController.swift; sourceTree = "<group>"; };
+		4BFCD203224CAF6100CD9544 /* ShareTargetSearchResultTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTargetSearchResultTableViewController.swift; sourceTree = "<group>"; };
 		4BFD6059212A875F009E9838 /* FlexBoxComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexBoxComponent.swift; sourceTree = "<group>"; };
 		4BFD605B212A8775009E9838 /* FlexTextComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexTextComponent.swift; sourceTree = "<group>"; };
 		4BFD605D212A8BA6009E9838 /* FlexComponentMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexComponentMessageTests.swift; sourceTree = "<group>"; };
@@ -719,7 +719,7 @@
 				4B3D78BA22420BEA00DE27D1 /* PageTabView.swift */,
 				D16D5323224872A300BAA3B4 /* ShareTarget.swift */,
 				D16D5325224873C700BAA3B4 /* ShareTargetSelectingViewController.swift */,
-				4BFCD203224CAF6100CD9544 /* ShareTargetSearchResultViewController.swift */,
+				4BFCD203224CAF6100CD9544 /* ShareTargetSearchResultTableViewController.swift */,
 				4B825622224CC36000D9F63E /* ShareTargetSearchController.swift */,
 				D16D53292248B01600BAA3B4 /* ShareTargetSelectingTableCell.swift */,
 				D16D5327224876B900BAA3B4 /* ColumnDataStore.swift */,
@@ -1613,7 +1613,7 @@
 				4B9A303F2121277400174C6F /* LocationMessage.swift in Sources */,
 				4B9A304B21213DBB00174C6F /* TemplateMessagePayload.swift in Sources */,
 				4BF45A86213783D000CCD28E /* CryptoHelpers.swift in Sources */,
-				4BFCD204224CAF6100CD9544 /* ShareTargetSearchResultViewController.swift in Sources */,
+				4BFCD204224CAF6100CD9544 /* ShareTargetSearchResultTableViewController.swift in Sources */,
 				4B3D78BB22420BEA00DE27D1 /* PageTabView.swift in Sources */,
 				4B45257621019EFB00A39D4F /* Session.swift in Sources */,
 				4B8FF4862105656500890AEF /* Delegate.swift in Sources */,

--- a/LineSDK/LineSDK.xcodeproj/project.pbxproj
+++ b/LineSDK/LineSDK.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		D1A591272139489E00AC080D /* JWK.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A591262139489E00AC080D /* JWK.swift */; };
 		D1A591292139495B00AC080D /* JWKSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A591282139495B00AC080D /* JWKSet.swift */; };
 		DB0AFF612247FB2E002729AD /* PageTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0AFF602247FB2E002729AD /* PageTabViewTests.swift */; };
+		DB115EF822537F1000C16B0C /* ShareTargetSearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB115EF722537F1000C16B0C /* ShareTargetSearchResultViewController.swift */; };
 		DBDCFD322126BD7200E8327A /* GetApproversInFriendsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */; };
 		DBDCFD342126CB6300E8327A /* GetApproversInFriendsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */; };
 		DBE4E36D211D6C1A00184D66 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE4E36C211D6C1A00184D66 /* User.swift */; };
@@ -541,6 +542,7 @@
 		D1A591262139489E00AC080D /* JWK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWK.swift; sourceTree = "<group>"; };
 		D1A591282139495B00AC080D /* JWKSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKSet.swift; sourceTree = "<group>"; };
 		DB0AFF602247FB2E002729AD /* PageTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTabViewTests.swift; sourceTree = "<group>"; };
+		DB115EF722537F1000C16B0C /* ShareTargetSearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTargetSearchResultViewController.swift; sourceTree = "<group>"; };
 		DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsRequest.swift; sourceTree = "<group>"; };
 		DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsTests.swift; sourceTree = "<group>"; };
 		DBE4E36C211D6C1A00184D66 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -720,6 +722,7 @@
 				D16D5323224872A300BAA3B4 /* ShareTarget.swift */,
 				D16D5325224873C700BAA3B4 /* ShareTargetSelectingViewController.swift */,
 				4BFCD203224CAF6100CD9544 /* ShareTargetSearchResultTableViewController.swift */,
+				DB115EF722537F1000C16B0C /* ShareTargetSearchResultViewController.swift */,
 				4B825622224CC36000D9F63E /* ShareTargetSearchController.swift */,
 				D16D53292248B01600BAA3B4 /* ShareTargetSelectingTableCell.swift */,
 				D16D5327224876B900BAA3B4 /* ColumnDataStore.swift */,
@@ -1680,6 +1683,7 @@
 				4B7FEDC6221E4245003F7369 /* ResultUtils.swift in Sources */,
 				4B4F0B8421084755006D17F5 /* UserProfile.swift in Sources */,
 				4BFD605A212A875F009E9838 /* FlexBoxComponent.swift in Sources */,
+				DB115EF822537F1000C16B0C /* ShareTargetSearchResultViewController.swift in Sources */,
 				4B4525712101938F00A39D4F /* Request.swift in Sources */,
 				4BFD605C212A8775009E9838 /* FlexTextComponent.swift in Sources */,
 				4B9A305421215A1A00174C6F /* TemplateConfirmPayload.swift in Sources */,

--- a/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultTableViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultTableViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ShareTargetSearchResultViewController.swift
+//  ShareTargetSearchResultTableViewController.swift
 //
 //  Copyright (c) 2016-present, LINE Corporation. All rights reserved.
 //
@@ -21,7 +21,7 @@
 
 import UIKit
 
-final class ShareTargetSearchResultViewController: UITableViewController, ShareTargetTableViewStyling {
+final class ShareTargetSearchResultTableViewController: UITableViewController, ShareTargetTableViewStyling {
 
     typealias ColumnIndex = ColumnDataStore<ShareTarget>.ColumnIndex
 
@@ -154,7 +154,7 @@ final class ShareTargetSearchResultViewController: UITableViewController, ShareT
     }
 }
 
-extension ShareTargetSearchResultViewController {
+extension ShareTargetSearchResultTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let selectedIndex = filteredIndexes[indexPath.section][indexPath.row]

--- a/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultViewController.swift
@@ -1,0 +1,46 @@
+//
+//  ShareTargetSearchResultViewController.swift
+//
+//  Copyright (c) 2016-present, LINE Corporation. All rights reserved.
+//
+//  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+//  copy and distribute this software in source code or binary form for use
+//  in connection with the web services and APIs provided by LINE Corporation.
+//
+//  As with any software that integrates with the LINE Corporation platform, your use of this software
+//  is subject to the LINE Developers Agreement [http://terms2.line.me/LINE_Developers_Agreement].
+//  This copyright notice shall be included in all copies or substantial portions of the software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import UIKit
+
+class ShareTargetSearchResultViewController: UIViewController {
+
+    let store: ColumnDataStore<ShareTarget>
+
+    let tableViewController: ShareTargetSearchResultTableViewController
+
+    init(store: ColumnDataStore<ShareTarget>) {
+        self.store = store
+        self.tableViewController = ShareTargetSearchResultTableViewController(store: store)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        automaticallyAdjustsScrollViewInsets = false
+        addChild(tableViewController, to: view)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/LineSDK/LineSDK/SharingUI/ShareTargetSelectingViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareTargetSelectingViewController.swift
@@ -41,13 +41,13 @@ final class ShareTargetSelectingViewController: UITableViewController, ShareTarg
 
     // Search
     private let searchController: ShareTargetSearchController
-    private let resultTableViewController: ShareTargetSearchResultViewController
+    private let resultTableViewController: ShareTargetSearchResultTableViewController
 
     init(store: ColumnDataStore<ShareTarget>, columnIndex: Int) {
         self.store = store
         self.columnIndex = columnIndex
 
-        let resultTableViewController = ShareTargetSearchResultViewController(store: store)
+        let resultTableViewController = ShareTargetSearchResultTableViewController(store: store)
         self.resultTableViewController = resultTableViewController
 
         let searchController = ShareTargetSearchController(searchResultsController: resultTableViewController)

--- a/LineSDK/LineSDK/SharingUI/ShareTargetSelectingViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareTargetSelectingViewController.swift
@@ -41,16 +41,16 @@ final class ShareTargetSelectingViewController: UITableViewController, ShareTarg
 
     // Search
     private let searchController: ShareTargetSearchController
-    private let resultTableViewController: ShareTargetSearchResultTableViewController
+    private let resultViewController: ShareTargetSearchResultViewController
 
     init(store: ColumnDataStore<ShareTarget>, columnIndex: Int) {
         self.store = store
         self.columnIndex = columnIndex
 
-        let resultTableViewController = ShareTargetSearchResultTableViewController(store: store)
-        self.resultTableViewController = resultTableViewController
+        let resultViewController = ShareTargetSearchResultViewController(store: store)
+        self.resultViewController = resultViewController
 
-        let searchController = ShareTargetSearchController(searchResultsController: resultTableViewController)
+        let searchController = ShareTargetSearchController(searchResultsController: resultViewController)
         self.searchController = searchController
 
         super.init(style: .plain)
@@ -169,11 +169,11 @@ extension ShareTargetSelectingViewController {
 // MARK: - Search Results Updating
 extension ShareTargetSelectingViewController: UISearchResultsUpdating {
     public func updateSearchResults(for searchController: UISearchController) {
-        resultTableViewController.tableView.isHidden = false
+        resultViewController.view.isHidden = false
         guard let text = searchController.searchBar.text?.trimmingCharacters(in: .whitespaces) else {
             return
         }
-        resultTableViewController.searchText = text
+        resultViewController.tableViewController.searchText = text
     }
 }
 
@@ -189,11 +189,11 @@ extension ShareTargetSelectingViewController: UISearchBarDelegate {
 
 extension ShareTargetSelectingViewController: UISearchControllerDelegate {
     func didPresentSearchController(_ searchController: UISearchController) {
-        resultTableViewController.start()
+        resultViewController.tableViewController.start()
     }
 
     func willDismissSearchController(_ searchController: UISearchController) {
-        resultTableViewController.clear()
+        resultViewController.tableViewController.clear()
     }
 }
 


### PR DESCRIPTION
## Note
- Rename `ShareTargetSearchResultTableViewController` to `ShareTargetSearchResultViewController`
- For easier add selected panel view to search result table viewController, add a viewController to hold the original `ShareTargetSearchResultTableViewController`
- the main change part could be view in the commit: https://github.com/line/line-sdk-ios-swift/commit/cd95abc6f4f33b2a1c3224713df288d6c285a0fb