### PR TITLE
Extract ShareRootViewController

### DIFF
--- a/LineSDK/LineSDK.xcodeproj/project.pbxproj
+++ b/LineSDK/LineSDK.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		D1A591292139495B00AC080D /* JWKSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A591282139495B00AC080D /* JWKSet.swift */; };
 		DB0AFF612247FB2E002729AD /* PageTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0AFF602247FB2E002729AD /* PageTabViewTests.swift */; };
 		DB115EF822537F1000C16B0C /* ShareTargetSearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB115EF722537F1000C16B0C /* ShareTargetSearchResultViewController.swift */; };
+		DB115EFA2254660C00C16B0C /* ShareRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB115EF92254660C00C16B0C /* ShareRootViewController.swift */; };
 		DBDCFD322126BD7200E8327A /* GetApproversInFriendsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */; };
 		DBDCFD342126CB6300E8327A /* GetApproversInFriendsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */; };
 		DBE4E36D211D6C1A00184D66 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE4E36C211D6C1A00184D66 /* User.swift */; };
@@ -543,6 +544,7 @@
 		D1A591282139495B00AC080D /* JWKSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKSet.swift; sourceTree = "<group>"; };
 		DB0AFF602247FB2E002729AD /* PageTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTabViewTests.swift; sourceTree = "<group>"; };
 		DB115EF722537F1000C16B0C /* ShareTargetSearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTargetSearchResultViewController.swift; sourceTree = "<group>"; };
+		DB115EF92254660C00C16B0C /* ShareRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareRootViewController.swift; sourceTree = "<group>"; };
 		DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsRequest.swift; sourceTree = "<group>"; };
 		DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsTests.swift; sourceTree = "<group>"; };
 		DBE4E36C211D6C1A00184D66 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -716,6 +718,7 @@
 			isa = PBXGroup;
 			children = (
 				4B5B0EF22241DEA900BA59A0 /* ShareViewController.swift */,
+				DB115EF92254660C00C16B0C /* ShareRootViewController.swift */,
 				4B392663224DE2E1006485B4 /* ShareTargetSelectingSectionHeaderView.swift */,
 				4B5B0EF42241DF3E00BA59A0 /* PageViewController.swift */,
 				4B3D78BA22420BEA00DE27D1 /* PageTabView.swift */,
@@ -1633,6 +1636,7 @@
 				4BB002C62244758000FB8BD8 /* ImageDownloader.swift in Sources */,
 				4BEB4926212BA2FD00BA946A /* FlexSeparatorComponent.swift in Sources */,
 				4BF5353D212A7E8E00EA602A /* FlexCarouselContainer.swift in Sources */,
+				DB115EFA2254660C00C16B0C /* ShareRootViewController.swift in Sources */,
 				3F75523121244502004AC047 /* LoginButton.swift in Sources */,
 				4BBAFC472101C8A100E7BFF6 /* AccessTokenStore.swift in Sources */,
 				4B9058DC21007C8C004D717F /* LoginResult.swift in Sources */,

--- a/LineSDK/LineSDK/SharingUI/ShareRootViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareRootViewController.swift
@@ -22,17 +22,10 @@
 import UIKit
 
 protocol ShareRootViewControllerDelegate: AnyObject {
-    func shareViewController(
+    func shareRootViewController(
         _ controller: ShareRootViewController,
         didFailLoadingListType shareType: MessageShareTargetType,
         withError error: LineSDKError)
-}
-
-extension ShareRootViewControllerDelegate {
-    func shareViewController(
-        _ controller: ShareRootViewController,
-        didFailLoadingListType shareType: MessageShareTargetType,
-        withError error: LineSDKError) { }
 }
 
 class ShareRootViewController: UIViewController {
@@ -151,7 +144,7 @@ extension ShareRootViewController {
             case .success:
                 break
             case .failure(let error):
-                self.shareDelegate?.shareViewController(self, didFailLoadingListType: .friends, withError: error)
+                self.shareDelegate?.shareRootViewController(self, didFailLoadingListType: .friends, withError: error)
             }
         }
 
@@ -162,7 +155,7 @@ extension ShareRootViewController {
             case .success:
                 break
             case .failure(let error):
-                self.shareDelegate?.shareViewController(self, didFailLoadingListType: .groups, withError: error)
+                self.shareDelegate?.shareRootViewController(self, didFailLoadingListType: .groups, withError: error)
             }
         }
 

--- a/LineSDK/LineSDK/SharingUI/ShareRootViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareRootViewController.swift
@@ -1,0 +1,237 @@
+//
+//  ShareRootViewController.swift
+//
+//  Copyright (c) 2016-present, LINE Corporation. All rights reserved.
+//
+//  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+//  copy and distribute this software in source code or binary form for use
+//  in connection with the web services and APIs provided by LINE Corporation.
+//
+//  As with any software that integrates with the LINE Corporation platform, your use of this software
+//  is subject to the LINE Developers Agreement [http://terms2.line.me/LINE_Developers_Agreement].
+//  This copyright notice shall be included in all copies or substantial portions of the software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import UIKit
+
+protocol ShareRootViewControllerDelegate: AnyObject {
+    func shareViewController(
+        _ controller: ShareRootViewController,
+        didFailLoadingListType shareType: MessageShareTargetType,
+        withError error: LineSDKError)
+}
+
+extension ShareRootViewControllerDelegate {
+    func shareViewController(
+        _ controller: ShareRootViewController,
+        didFailLoadingListType shareType: MessageShareTargetType,
+        withError error: LineSDKError) { }
+}
+
+class ShareRootViewController: UIViewController {
+    typealias ColumnIndex = ColumnDataStore<ShareTarget>.ColumnIndex
+
+    private let store = ColumnDataStore<ShareTarget>(columnCount: MessageShareTargetType.allCases.count)
+
+    // States
+    @objc dynamic private var allLoaded: Bool = false
+
+    // Observers
+    private var selectingObserver: NotificationToken!
+    private var deselectingObserver: NotificationToken!
+
+    private var loadedObserver: NSKeyValueObservation?
+
+    weak var shareDelegate: ShareRootViewControllerDelegate?
+
+    private lazy var selectedTargetView = SelectedTargetView()
+
+    private var indicatorContainer: UIView?
+
+    private lazy var pageViewController: PageViewController = {
+        let controllers = MessageShareTargetType.allCases.map { index -> ShareTargetSelectingViewController in
+            let controller = ShareTargetSelectingViewController(store: store, columnIndex: index.rawValue)
+            // Force load view for pages to setup table view initial state.
+            _ = controller.view
+            return controller
+        }
+
+        controllers.forEach { $0.delegate = self }
+
+        let pages = zip(MessageShareTargetType.allCases, controllers).map {
+            index, controller -> PageViewController.Page in
+            return .init(viewController: controller, title: index.title)
+        }
+
+        return PageViewController(pages: pages)
+    }()
+
+    deinit {
+        ImageManager.shared.purgeCache()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupSubviews()
+
+        setupLayouts()
+
+        // default
+        selectedTargetView.setMode(.hide, animated: false)
+
+        // Wait for child view controllers setup themselves.
+        loadGraphList()
+        setupObservers()
+    }
+
+    private func setupObservers() {
+        selectingObserver = NotificationCenter.default.addObserver(
+            forName: .columnDataStoreDidSelect, object: store, queue: nil)
+        {
+            [unowned self] noti in
+            self.handleSelectingChange(noti)
+        }
+
+        deselectingObserver = NotificationCenter.default.addObserver(
+            forName: .columnDataStoreDidDeselect, object: store, queue: nil)
+        {
+            [unowned self] noti in
+            self.handleSelectingChange(noti)
+        }
+    }
+
+    private func setupSubviews() {
+        addChild(pageViewController, to: view)
+        view.addSubview(selectedTargetView)
+    }
+
+    private func setupLayouts() {
+        selectedTargetView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            selectedTargetView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            selectedTargetView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            selectedTargetView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            selectedTargetView.topAnchor.constraint(equalTo: safeBottomAnchor,
+                                                    constant: -SelectedTargetView.Design.height)
+            ])
+    }
+}
+
+// MARK: - Controller Actions
+extension ShareRootViewController {
+
+    private func loadGraphList() {
+
+        let friendsRequest = GetFriendsRequest(sort: .relation, pageToken: nil)
+        let chainedFriendsRequest = ChainedPaginatedRequest(originalRequest: friendsRequest)
+        chainedFriendsRequest.onPageLoaded.delegate(on: self) { (self, response) in
+            self.store.append(data: response.friends, to: MessageShareTargetType.friends.rawValue)
+        }
+
+        let groupsRequest = GetGroupsRequest(pageToken: nil)
+        let chainedGroupsRequest = ChainedPaginatedRequest(originalRequest: groupsRequest)
+        chainedGroupsRequest.onPageLoaded.delegate(on: self) { (self, response) in
+            self.store.append(data: response.groups, to: MessageShareTargetType.groups.rawValue)
+        }
+
+        let sendingDispatchGroup = DispatchGroup()
+
+        sendingDispatchGroup.enter()
+        Session.shared.send(chainedFriendsRequest) { result in
+            sendingDispatchGroup.leave()
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                self.shareDelegate?.shareViewController(self, didFailLoadingListType: .friends, withError: error)
+            }
+        }
+
+        sendingDispatchGroup.enter()
+        Session.shared.send(chainedGroupsRequest) { result in
+            sendingDispatchGroup.leave()
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                self.shareDelegate?.shareViewController(self, didFailLoadingListType: .groups, withError: error)
+            }
+        }
+
+        sendingDispatchGroup.notify(queue: .main) {
+            self.allLoaded = true
+        }
+    }
+
+    private func handleSelectingChange(_ notification: Notification) {
+        let count = store.selected.count
+        if count == 0 {
+            navigationItem.rightBarButtonItem = nil
+        } else {
+            let title = Localization.string("common.action.send")
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: "\(title) (\(count))", style: .plain, target: self, action: #selector(sendMessage))
+        }
+    }
+
+    @objc private func sendMessage() {
+        print("Send")
+    }
+}
+
+// MARK: - Selecting view controller delegate
+extension ShareRootViewController: ShareTargetSelectingViewControllerDelegate {
+    func shouldSearchStart(_ viewController: ShareTargetSelectingViewController) -> Bool {
+        if allLoaded {
+            return true
+        }
+
+        addLoadingIndicator()
+        loadedObserver = observe(\.allLoaded, options: .new) { [weak self] controller, change in
+            guard let self = self else { return }
+            if let loaded = change.newValue, loaded {
+                self.removeLoadingIndicator()
+                self.loadedObserver = nil
+                viewController.continueSearch()
+            }
+        }
+
+        return false
+    }
+
+    private func addLoadingIndicator() {
+        let container = UIView(frame: .zero)
+        let indicator = UIActivityIndicatorView(style: .whiteLarge)
+        indicator.color = .gray
+
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(indicator)
+        NSLayoutConstraint.activate([
+            indicator.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            indicator.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            ])
+
+        // Add the loading indicator container to root view controller (page), so user has a chance to
+        // close the sharing UI by tapping "Close" button in the navigation bar.
+        view.addChildSubview(container)
+
+        indicator.startAnimating()
+
+        indicatorContainer = container
+    }
+
+    private func removeLoadingIndicator() {
+        guard let container = indicatorContainer else {
+            return
+        }
+        container.removeFromSuperview()
+    }
+}

--- a/LineSDK/LineSDK/SharingUI/ShareRootViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareRootViewController.swift
@@ -21,7 +21,7 @@
 
 import UIKit
 
-protocol ShareRootViewControllerDelegate: AnyObject {
+protocol ShareRootViewControllerDelegate: class {
     func shareRootViewController(
         _ controller: ShareRootViewController,
         didFailLoadingListType shareType: MessageShareTargetType,

--- a/LineSDK/LineSDK/SharingUI/ShareViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareViewController.swift
@@ -70,88 +70,24 @@ public class ShareViewController: UINavigationController {
         static var navigationBarTextColor:  UIColor { return  .white }
     }
 
-    typealias ColumnIndex = ColumnDataStore<ShareTarget>.ColumnIndex
-
     public var navigationBarTintColor = Design.navigationBarTintColor { didSet { updateNavigationStyles() } }
     public var navigationBarTextColor = Design.navigationBarTextColor { didSet { updateNavigationStyles() } }
     public var statusBarStyle = Design.preferredStatusBarStyle { didSet { updateNavigationStyles() } }
 
     // Root & Data
-    private var rootViewController: UIViewController! { didSet { print("Set") } }
-    private var store: ColumnDataStore<ShareTarget>!
-
-    // States
-    @objc dynamic private var allLoaded: Bool = false
-
-    // Observers
-    private var selectingObserver: NotificationToken!
-    private var deselectingObserver: NotificationToken!
-
-    private var loadedObserver: NSKeyValueObservation?
+    private let rootViewController = ShareRootViewController()
 
     public weak var shareDelegate: ShareViewControllerDelegate?
 
-    private lazy var selectedTargetView = SelectedTargetView()
-
-    private var indicatorContainer: UIView?
-
     // MARK: - Initializers
     public init() {
-        let store = ColumnDataStore<ShareTarget>(columnCount: MessageShareTargetType.allCases.count)
-        let controllers = MessageShareTargetType.allCases.map { index -> ShareTargetSelectingViewController in
-            let controller = ShareTargetSelectingViewController(store: store, columnIndex: index.rawValue)
-            // Force load view for pages to setup table view initial state.
-            _ = controller.view
-            return controller
-        }
-
-        let pages = zip(MessageShareTargetType.allCases, controllers).map {
-            index, controller -> PageViewController.Page in
-            return .init(viewController: controller, title: index.title)
-        }
-
-        let rootViewController = PageViewController(pages: pages)
-
-        super.init(rootViewController: rootViewController)
-
-        self.store = store
-        self.rootViewController = rootViewController
-        controllers.forEach { $0.delegate = self }
-
+        super.init(nibName: nil, bundle: nil)
+        self.viewControllers = [rootViewController]
         updateNavigationStyles()
-    }
-
-    deinit {
-        ImageManager.shared.purgeCache()
-    }
-
-    @objc
-    func foo() {
-        selectedTargetView.setMode((selectedTargetView.mode == .show) ? .hide : .show,
-                                   animated: true)
-    }
-
-    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - Lift Cycle
-    public override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        setupSubviews()
-        setupLayouts()
-
-        // default
-        selectedTargetView.setMode(.hide, animated: false)
-
-        // Wait for child view controllers setup themselves.
-        loadGraphList()
-        setupObservers()
     }
 
     // MARK: - Setup & Style
@@ -176,36 +112,6 @@ public class ShareViewController: UINavigationController {
         navigationBar.titleTextAttributes = [.foregroundColor: navigationBarTextColor]
     }
 
-    private func setupObservers() {
-        selectingObserver = NotificationCenter.default.addObserver(
-            forName: .columnDataStoreDidSelect, object: store, queue: nil)
-        {
-            [unowned self] noti in
-            self.handleSelectingChange(noti)
-        }
-
-        deselectingObserver = NotificationCenter.default.addObserver(
-            forName: .columnDataStoreDidDeselect, object: store, queue: nil)
-        {
-            [unowned self] noti in
-            self.handleSelectingChange(noti)
-        }
-    }
-  
-    private func setupSubviews() {
-        view.addSubview(selectedTargetView)
-    }
-
-    private func setupLayouts() {
-        selectedTargetView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            selectedTargetView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            selectedTargetView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            selectedTargetView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            selectedTargetView.topAnchor.constraint(equalTo: safeBottomAnchor,
-                                                    constant: -SelectedTargetView.Design.height)
-            ])
-    }
 }
 
 // MARK: - Controller Actions
@@ -214,64 +120,6 @@ extension ShareViewController {
         dismiss(animated: true) {
             self.shareDelegate?.shareViewControllerDidCancelSharing(self)
         }
-    }
-
-    private func loadGraphList() {
-
-        let friendsRequest = GetFriendsRequest(sort: .relation, pageToken: nil)
-        let chainedFriendsRequest = ChainedPaginatedRequest(originalRequest: friendsRequest)
-        chainedFriendsRequest.onPageLoaded.delegate(on: self) { (self, response) in
-            self.store.append(data: response.friends, to: MessageShareTargetType.friends.rawValue)
-        }
-
-        let groupsRequest = GetGroupsRequest(pageToken: nil)
-        let chainedGroupsRequest = ChainedPaginatedRequest(originalRequest: groupsRequest)
-        chainedGroupsRequest.onPageLoaded.delegate(on: self) { (self, response) in
-            self.store.append(data: response.groups, to: MessageShareTargetType.groups.rawValue)
-        }
-
-        let sendingDispatchGroup = DispatchGroup()
-
-        sendingDispatchGroup.enter()
-        Session.shared.send(chainedFriendsRequest) { result in
-            sendingDispatchGroup.leave()
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                self.shareDelegate?.shareViewController(self, didFailLoadingListType: .friends, withError: error)
-            }
-        }
-
-        sendingDispatchGroup.enter()
-        Session.shared.send(chainedGroupsRequest) { result in
-            sendingDispatchGroup.leave()
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                self.shareDelegate?.shareViewController(self, didFailLoadingListType: .groups, withError: error)
-            }
-        }
-
-        sendingDispatchGroup.notify(queue: .main) {
-            self.allLoaded = true
-        }
-    }
-
-    private func handleSelectingChange(_ notification: Notification) {
-        let count = store.selected.count
-        if count == 0 {
-            rootViewController.navigationItem.rightBarButtonItem = nil
-        } else {
-            let title = Localization.string("common.action.send")
-            rootViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(
-                title: "\(title) (\(count))", style: .plain, target: self, action: #selector(sendMessage))
-        }
-    }
-
-    @objc private func sendMessage() {
-        print("Send")
     }
 }
 
@@ -298,51 +146,10 @@ extension ShareViewController {
     }
 }
 
-// MARK: - Selecting view controller delegate
-extension ShareViewController: ShareTargetSelectingViewControllerDelegate {
-    func shouldSearchStart(_ viewController: ShareTargetSelectingViewController) -> Bool {
-        if allLoaded {
-            return true
-        }
-
-        addLoadingIndicator()
-        loadedObserver = observe(\.allLoaded, options: .new) { [weak self] controller, change in
-            guard let self = self else { return }
-            if let loaded = change.newValue, loaded {
-                self.removeLoadingIndicator()
-                self.loadedObserver = nil
-                viewController.continueSearch()
-            }
-        }
-
-        return false
-    }
-
-    private func addLoadingIndicator() {
-        let container = UIView(frame: .zero)
-        let indicator = UIActivityIndicatorView(style: .whiteLarge)
-        indicator.color = .gray
-
-        indicator.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(indicator)
-        NSLayoutConstraint.activate([
-            indicator.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            indicator.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-        ])
-
-        // Add the loading indicator container to root view controller (page), so user has a chance to
-        // close the sharing UI by tapping "Close" button in the navigation bar.
-        rootViewController.view.addChildSubview(container)
-
-        indicator.startAnimating()
-
-        indicatorContainer = container
-    }
-
-    private func removeLoadingIndicator() {
-        guard let container = indicatorContainer else {
-            return
-        }
-        container.removeFromSuperview()
+extension ShareViewController: ShareRootViewControllerDelegate {
+    func shareViewController(_ controller: ShareRootViewController,
+                             didFailLoadingListType shareType: MessageShareTargetType,
+                             withError error: LineSDKError) {
+        shareDelegate?.shareViewController(self, didFailLoadingListType: shareType, withError: error)
     }
 }

--- a/LineSDK/LineSDK/SharingUI/ShareViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareViewController.swift
@@ -147,9 +147,9 @@ extension ShareViewController {
 }
 
 extension ShareViewController: ShareRootViewControllerDelegate {
-    func shareViewController(_ controller: ShareRootViewController,
-                             didFailLoadingListType shareType: MessageShareTargetType,
-                             withError error: LineSDKError) {
+    func shareRootViewController(_ controller: ShareRootViewController,
+                                 didFailLoadingListType shareType: MessageShareTargetType,
+                                 withError error: LineSDKError) {
         shareDelegate?.shareViewController(self, didFailLoadingListType: shareType, withError: error)
     }
 }


### PR DESCRIPTION
## About
- Extract ShareRootViewController, for not doing view / life cycle stuff in UINavigationController
- Basically move logic into ShareRootViewController, leave only styling in ShareViewController(UINavigationController)