### PR TITLE
Order the search result section

### DIFF
--- a/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultTableViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultTableViewController.swift
@@ -48,6 +48,9 @@ final class ShareTargetSearchResultTableViewController: UITableViewController, S
         print("Deinit: \(self)")
     }
 
+    // The order of search result section.
+    var sectionOrder: [MessageShareTargetType] = [.friends, .groups]
+
     var searchText: String = "" {
         didSet {
             guard searchText != oldValue else { return }
@@ -102,7 +105,8 @@ final class ShareTargetSearchResultTableViewController: UITableViewController, S
             return
         }
 
-        let indexPath = IndexPath(row: row, section: index.column)
+        let section = actualSection(index.column)
+        let indexPath = IndexPath(row: row, section: section)
 
         if let cell = tableView.cellForRow(at: indexPath) as? ShareTargetSelectingTableCell {
             let target = store.data(at: index)
@@ -122,7 +126,7 @@ final class ShareTargetSearchResultTableViewController: UITableViewController, S
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return filteredIndexes[section].count
+        return filteredIndexes[actualSection(section)].count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -130,7 +134,8 @@ final class ShareTargetSearchResultTableViewController: UITableViewController, S
             withIdentifier: ShareTargetSelectingTableCell.reuseIdentifier,
             for: indexPath) as! ShareTargetSelectingTableCell
 
-        let dataIndex = filteredIndexes[indexPath.section][indexPath.row]
+        let section = actualSection(indexPath.section)
+        let dataIndex = filteredIndexes[section][indexPath.row]
         let target = store.data(at: dataIndex)
         let selected = store.isSelected(at: dataIndex)
         cell.setShareTarget(target, selected: selected, highlightText: searchText)
@@ -138,6 +143,7 @@ final class ShareTargetSearchResultTableViewController: UITableViewController, S
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        let section = actualSection(section)
         if filteredIndexes[section].isEmpty {
             return 0
         }
@@ -145,6 +151,7 @@ final class ShareTargetSearchResultTableViewController: UITableViewController, S
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let section = actualSection(section)
         if filteredIndexes[section].isEmpty {
             return nil
         }
@@ -152,12 +159,17 @@ final class ShareTargetSearchResultTableViewController: UITableViewController, S
         view.titleLabel.text = MessageShareTargetType(rawValue: section)?.title
         return view
     }
+
+    private func actualSection(_ section: Int) -> Int {
+        return sectionOrder[section].rawValue
+    }
 }
 
 extension ShareTargetSearchResultTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        let selectedIndex = filteredIndexes[indexPath.section][indexPath.row]
+        let section = actualSection(indexPath.section)
+        let selectedIndex = filteredIndexes[section][indexPath.row]
         let toggled = store.toggleSelect(atColumn: selectedIndex.column, row: selectedIndex.row)
         if !toggled {
             popSelectingLimitAlert(max: store.maximumSelectedCount)

--- a/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareTargetSearchResultViewController.swift
@@ -36,6 +36,11 @@ class ShareTargetSearchResultViewController: UIViewController {
 
     private let tableViewController: ShareTargetSearchResultTableViewController
 
+    var sectionOrder: [MessageShareTargetType] {
+        get { return tableViewController.sectionOrder }
+        set { tableViewController.sectionOrder = newValue }
+    }
+
     init(store: ColumnDataStore<ShareTarget>) {
         self.store = store
         self.tableViewController = ShareTargetSearchResultTableViewController(store: store)

--- a/LineSDK/LineSDK/SharingUI/ShareTargetSelectingViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/ShareTargetSelectingViewController.swift
@@ -48,6 +48,16 @@ final class ShareTargetSelectingViewController: UITableViewController, ShareTarg
         self.columnIndex = columnIndex
 
         let resultViewController = ShareTargetSearchResultViewController(store: store)
+
+        switch MessageShareTargetType(rawValue: columnIndex) {
+        case .friends?:
+            resultViewController.sectionOrder = [.friends, .groups]
+        case .groups?:
+            resultViewController.sectionOrder = [.groups, .friends]
+        case .none:
+            fatalError("The input column index should match a message share target type.")
+        }
+
         self.resultViewController = resultViewController
 
         let searchController = ShareTargetSearchController(searchResultsController: resultViewController)


### PR DESCRIPTION
Currently, the search result table orders the sections in `[.friends, .groups]`. This PR adds support for reordering the sections. If users enter the search screen from the Group tab, the search result will place `.groups` first, then `friends`. This improves UX a bit.