### PR TITLE
Add swift_versions for CocoaPods 1.7.0 & Swift 5.0

### DIFF
--- a/LineSDKSwift.podspec
+++ b/LineSDKSwift.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   
   s.module_name         = "LineSDK"
   s.swift_version       = "4.2"
+  s.swift_versions      = ['4.2', '5.0']
   s.source              = { :git => "https://github.com/line/line-sdk-ios-swift.git", :tag => "#{s.version}" }
 
   s.default_subspecs    = "Core"

--- a/LineSDKSwift.podspec
+++ b/LineSDKSwift.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   s.module_name         = "LineSDK"
   s.swift_version       = "4.2"
-  s.swift_versions      = ['4.2', '5.0']
+  s.swift_versions      = ["4.2", "5.0"]
   s.source              = { :git => "https://github.com/line/line-sdk-ios-swift.git", :tag => "#{s.version}" }
 
   s.default_subspecs    = "Core"


### PR DESCRIPTION
CocoaPods 1.7.0 adds `swift_versions` for libraries to support multiple Swift versions.
Since this library supports both Swift 4.2 and 5.0, I suggest adding this property in podspec.