### PR TITLE
Make refresh token non-public

### DIFF
--- a/LineSDK/LineSDK/Login/Model/AccessToken.swift
+++ b/LineSDK/LineSDK/Login/Model/AccessToken.swift
@@ -59,7 +59,11 @@ public struct AccessToken: Codable, AccessTokenType, Equatable {
     public let IDTokenRaw: String?
 
     /// The refresh token bound to the access token.
-    public let refreshToken: String
+    @available(*, unavailable,
+    message: "`refreshToken` is not publicly provided anymore. You should not access or store it yourself.")
+    public var refreshToken: String { Log.fatalError("`refreshToken` is not publicly provided anymore.") }
+
+    let _refreshToken: String
 
     /// Permissions of the access token.
     public let permissions: [LoginPermission]
@@ -100,7 +104,7 @@ public struct AccessToken: Codable, AccessTokenType, Equatable {
             IDToken = nil
         }
 
-        refreshToken = try container.decode(String.self, forKey: .refreshToken)
+        _refreshToken = try container.decode(String.self, forKey: .refreshToken)
         permissions = try container.decodeLoginPermissions(forKey: .scope)
         tokenType = try container.decode(String.self, forKey: .tokenType)
     }
@@ -112,7 +116,7 @@ public struct AccessToken: Codable, AccessTokenType, Equatable {
         try container.encode(expiresIn, forKey: .expiresIn)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encodeIfPresent(IDTokenRaw, forKey: .IDTokenRaw)
-        try container.encode(refreshToken, forKey: .refreshToken)
+        try container.encode(_refreshToken, forKey: .refreshToken)
         try container.encodeLoginPermissions(permissions, forKey: .scope)
         try container.encode(tokenType, forKey: .tokenType)
     }

--- a/LineSDK/LineSDK/Networking/API.swift
+++ b/LineSDK/LineSDK/Networking/API.swift
@@ -51,7 +51,7 @@ public struct API {
         callbackQueue queue: CallbackQueue = .currentMainOrAsync,
         completionHandler completion: @escaping (Result<AccessToken, LineSDKError>) -> Void)
     {
-        guard let token = refreshToken ?? AccessTokenStore.shared.current?.refreshToken else {
+        guard let token = refreshToken ?? AccessTokenStore.shared.current?._refreshToken else {
             queue.execute { completion(.failure(LineSDKError.requestFailed(reason: .lackOfAccessToken))) }
             return
         }
@@ -154,7 +154,7 @@ public struct API {
             completion(result)
         }
 
-        guard let refreshToken = refreshToken ?? AccessTokenStore.shared.current?.refreshToken else {
+        guard let refreshToken = refreshToken ?? AccessTokenStore.shared.current?._refreshToken else {
             // No token input or found in store, just recognize it as success.
             queue.execute { completion(.success(())) }
             return

--- a/LineSDK/LineSDK/Networking/API.swift
+++ b/LineSDK/LineSDK/Networking/API.swift
@@ -36,7 +36,6 @@ public struct API {
     /// Refreshes the access token with `refreshToken`.
     ///
     /// - Parameters:
-    ///   - refreshToken: A refresh token. Optional. If not specified, the current refresh token is used.
     ///   - queue: The callback queue that is used for `completion`. The default value is
     ///            `.currentMainOrAsync`. For more information, see `CallbackQueue`.
     ///   - completion: The completion closure to be invoked when the access token is refreshed.
@@ -47,11 +46,10 @@ public struct API {
     ///   manually because any API call will attempt to refresh the access token if necessary.
     ///
     public static func refreshAccessToken(
-        _ refreshToken: String? = nil,
         callbackQueue queue: CallbackQueue = .currentMainOrAsync,
         completionHandler completion: @escaping (Result<AccessToken, LineSDKError>) -> Void)
     {
-        guard let token = refreshToken ?? AccessTokenStore.shared.current?._refreshToken else {
+        guard let token = AccessTokenStore.shared.current?._refreshToken else {
             queue.execute { completion(.failure(LineSDKError.requestFailed(reason: .lackOfAccessToken))) }
             return
         }

--- a/LineSDK/LineSDKObjC/Login/Model/LineSDKAccessToken.swift
+++ b/LineSDK/LineSDKObjC/Login/Model/LineSDKAccessToken.swift
@@ -31,7 +31,6 @@ public class LineSDKAccessToken: NSObject {
     public var value: String { return _value.value }
     public var createdAt: Date { return _value.createdAt }
     public var IDToken: LineSDKJWT? { return _value.IDToken.map { .init($0) } }
-    public var refreshToken: String { return _value.refreshToken }
     public var permissions: [LineSDKLoginPermission] { return _value.permissions.map { .init($0) } }
     public var expiresAt: Date { return _value.expiresAt }
 

--- a/LineSDK/LineSDKObjC/Networking/LineSDKAPI.swift
+++ b/LineSDK/LineSDKObjC/Networking/LineSDKAPI.swift
@@ -30,22 +30,14 @@ public class LineSDKAPI: NSObject {
     public static func refreshAccessToken(
         completionHandler completion: @escaping (LineSDKAccessToken?, Error?) -> Void)
     {
-        refreshAccessToken(nil, completionHandler: completion)
+        refreshAccessToken(callbackQueue: .currentMainOrAsync, completionHandler: completion)
     }
     
     public static func refreshAccessToken(
-        _ refreshToken: String?,
-        completionHandler completion: @escaping (LineSDKAccessToken?, Error?) -> Void)
-    {
-        refreshAccessToken(refreshToken, callbackQueue: .currentMainOrAsync, completionHandler: completion)
-    }
-    
-    public static func refreshAccessToken(
-        _ refreshToken: String?,
         callbackQueue queue: LineSDKCallbackQueue,
         completionHandler completion: @escaping (LineSDKAccessToken?, Error?) -> Void)
     {
-        API.refreshAccessToken(refreshToken, callbackQueue: queue.unwrapped) { result in
+        API.refreshAccessToken(callbackQueue: queue.unwrapped) { result in
             result.map(LineSDKAccessToken.init).match(with: completion)
         }
     }

--- a/LineSDK/LineSDKObjCInterfaceTests/LineSDKAPIInterfaceTests.m
+++ b/LineSDK/LineSDKObjCInterfaceTests/LineSDKAPIInterfaceTests.m
@@ -32,11 +32,8 @@
 
 - (void)_testRefreshAccessTokenInterface {
     [LineSDKAPI refreshAccessTokenWithCompletionHandler:^(LineSDKAccessToken * token, NSError * error) {}];
-    [LineSDKAPI refreshAccessToken:nil
-                 completionHandler:^(LineSDKAccessToken * token, NSError * error) {}];
-    [LineSDKAPI refreshAccessToken:nil
-                     callbackQueue:[LineSDKCallbackQueue asyncMain]
-                 completionHandler:^(LineSDKAccessToken * token, NSError * error) {}];
+    [LineSDKAPI refreshAccessTokenWithCallbackQueue:[LineSDKCallbackQueue asyncMain]
+                                  completionHandler:^(LineSDKAccessToken * token, NSError * error) {}];
 }
 
 - (void)_testRevokeAccessTokenInterface {

--- a/LineSDK/LineSDKObjCInterfaceTests/LineSDKModelInterfaceTests.m
+++ b/LineSDK/LineSDKObjCInterfaceTests/LineSDKModelInterfaceTests.m
@@ -55,7 +55,6 @@
     XCTAssertNil(token.value);
     XCTAssertNil(token.createdAt);
     XCTAssertNil(token.IDToken);
-    XCTAssertNil(token.refreshToken);
     XCTAssertNil(token.permissions);
     XCTAssertNil(token.expiresAt);
     XCTAssertNil(token.json);

--- a/LineSDK/LineSDKTests/API/PostRefreshTokenRequestTests.swift
+++ b/LineSDK/LineSDKTests/API/PostRefreshTokenRequestTests.swift
@@ -46,7 +46,7 @@ class PostRefreshTokenRequestTests: APITests {
         let request = PostRefreshTokenRequest(channelID: "abc", refreshToken: "123123")
         runTestSuccess(for: request) { token in
             XCTAssertEqual(token.value, "123")
-            XCTAssertEqual(token.refreshToken, "abc")
+            XCTAssertEqual(token._refreshToken, "abc")
             XCTAssertEqual(token.tokenType, "Bearer")
             XCTAssertEqual(token.permissions, [LoginPermission.profile, LoginPermission.openID])
             XCTAssertEqual(token.expiresAt, token.createdAt.addingTimeInterval(token.expiresIn))

--- a/LineSDK/LineSDKTests/API/PostTokenExchangeRequestTests.swift
+++ b/LineSDK/LineSDKTests/API/PostTokenExchangeRequestTests.swift
@@ -70,7 +70,7 @@ class PostExchangeTokenRequestTests: APITests {
             optionalRedirectURI: "universal")
         runTestSuccess(for: request) { token in
             XCTAssertEqual(token.value, "123")
-            XCTAssertEqual(token.refreshToken, "abc")
+            XCTAssertEqual(token._refreshToken, "abc")
             XCTAssertEqual(token.tokenType, "Bearer")
             XCTAssertEqual(token.permissions, [LoginPermission.profile, LoginPermission(rawValue: "abcd")])
             XCTAssertEqual(token.expiresAt, token.createdAt.addingTimeInterval(token.expiresIn))

--- a/LineSDKSample/LineSDKSample/Login/UserDetailViewController.swift
+++ b/LineSDKSample/LineSDKSample/Login/UserDetailViewController.swift
@@ -77,12 +77,10 @@ class UserDetailViewController: UITableViewController, CellCopyable {
         case 0:
             content = ("Access", token?.value ?? "N/A")
         case 1:
-            content = ("Refresh", token?.refreshToken ?? "N/A")
-        case 2:
             content = ("Created", token?.createdAt.description ?? "N/A")
-        case 3:
+        case 2:
             content = ("Expire", token?.expiresAt.description ?? "N/A")
-        case 4:
+        case 3:
             let permissions = token?.permissions ?? []
             let text = permissions.map { $0.rawValue }.joined(separator: " ")
             content = ("Permissions", text)
@@ -96,7 +94,7 @@ class UserDetailViewController: UITableViewController, CellCopyable {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Section(rawValue: section)! {
         case .user: return 4
-        case .token: return 5
+        case .token: return 4
         }
     }
 


### PR DESCRIPTION
The refresh token is not intended to be used outside of the SDK itself. So we made it unavailable. 

The `@available` mark is for upgrading migration for now. Later we should rename the `_refreshToken` to an internal `refreshToken`.