### PR TITLE
Cancel presenting by gesture also triggers delegate method

### DIFF
--- a/LineSDK/LineSDK/SharingUI/Public/ShareViewController.swift
+++ b/LineSDK/LineSDK/SharingUI/Public/ShareViewController.swift
@@ -126,6 +126,7 @@ open class ShareViewController: UINavigationController {
     public init() {
         super.init(nibName: nil, bundle: nil)
         setupRootDelegates()
+        setupPresentationDelegate()
         self.viewControllers = [rootViewController]
         updateNavigationStyles()
     }
@@ -146,7 +147,9 @@ open class ShareViewController: UINavigationController {
     private func setupRootDelegates() {
         rootViewController.onCancelled.delegate(on: self) { (self, _) in
             if let shareDelegate = self.shareDelegate {
-                shareDelegate.shareViewControllerDidCancelSharing(self)
+                self.dismiss(animated: true) {
+                    shareDelegate.shareViewControllerDidCancelSharing(self)
+                }
             } else {
                 self.dismiss(animated: true)
             }
@@ -189,6 +192,10 @@ open class ShareViewController: UINavigationController {
         rootViewController.onShouldDismiss.delegate(on: self) { (self, _) in
             return self.shareDelegate?.shareViewControllerShouldDismissAfterSending(self) ?? true
         }
+    }
+
+    private func setupPresentationDelegate() {
+        presentationController?.delegate = self
     }
 
     private func updateNavigationStyles() {
@@ -257,5 +264,11 @@ extension ShareViewController {
             return .lackOfPermissions(lackPermissions)
         }
         return .authorized
+    }
+}
+
+extension ShareViewController: UIAdaptivePresentationControllerDelegate {
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        shareDelegate?.shareViewControllerDidCancelSharing(self)
     }
 }

--- a/LineSDK/LineSDK/SharingUI/Public/ShareViewControllerDelegate.swift
+++ b/LineSDK/LineSDK/SharingUI/Public/ShareViewControllerDelegate.swift
@@ -172,9 +172,7 @@ extension ShareViewControllerDelegate {
         didFailLoadingListType shareType: MessageShareTargetType,
         withError error: LineSDKError) { }
 
-    public func shareViewControllerDidCancelSharing(_ controller: ShareViewController) {
-        controller.dismiss(animated: true)
-    }
+    public func shareViewControllerDidCancelSharing(_ controller: ShareViewController) {}
 
     public func shareViewController(
         _ controller: ShareViewController,


### PR DESCRIPTION
This PR adds the ability to call the `didCancel` delegate method when user dismiss the sharing UI by swipe down gesture in iOS 13.

In earlier iOS versions, users can only dismiss a model by tapping the "Cancel" button. In iOS 13, they can also dismiss it by gesture by default. This provides the correct delegate invoking for that case.