### PR TITLE
Fix iOS 12 is not showing the `User Cancelled` message

### DIFF
--- a/LineSDKSample/LineSDKSample/UI/SampleUIHomeViewController.swift
+++ b/LineSDKSample/LineSDKSample/UI/SampleUIHomeViewController.swift
@@ -74,10 +74,8 @@ extension SampleUIHomeViewController: ShareViewControllerDelegate {
     }
 
     func shareViewControllerDidCancelSharing(_ controller: ShareViewController) {
-        dismiss(animated: true) {
-            UIAlertController.present(
-                in: self, title: nil, message: "User Cancelled", actions: [.init(title: "OK", style: .cancel)])
-        }
+        UIAlertController.present(
+            in: self, title: nil, message: "User Cancelled", actions: [.init(title: "OK", style: .cancel)])
     }
 
     func shareViewController(


### PR DESCRIPTION
- Remove the extra dismiss in sample proj, since the dismiss action are covered inside SDK.
- This also let iOS 12 and below, could see the `User Cancelled` alert.
- The `presentedViewController` is `nil` in 
```swift
// SampleUIHomeViewController.swift
func shareViewControllerDidCancelSharing(_ controller: ShareViewController) {
}
```