### PR TITLE
Support CocoaPods resource bundles

### DIFF
--- a/LineSDK/LineSDK/Login/LoginButton.swift
+++ b/LineSDK/LineSDK/Login/LoginButton.swift
@@ -167,7 +167,6 @@ open class LoginButton: UIButton {
     // This method is called when the style of `LoginButton` is changed.
     // It will update the appearance of button to new style you set.
     func updateButtonStyle() {
-        let bundle = Bundle(for: LoginButton.self)
         let imagesPairs: [(String, UIControl.State)]
         switch buttonSize {
         case .small:
@@ -183,7 +182,7 @@ open class LoginButton: UIButton {
         }
         
         imagesPairs.forEach { (imageName, state) in
-            setBackgroundImage(UIImage(named: imageName, in: bundle, compatibleWith: nil), for: state)
+            setBackgroundImage(UIImage(bundleNamed: imageName), for: state)
         }
         
         titleEdgeInsets = UIEdgeInsets(

--- a/LineSDK/LineSDK/Utils/Constant.swift
+++ b/LineSDK/LineSDK/Utils/Constant.swift
@@ -57,24 +57,32 @@ public struct Constant {
 
 extension Bundle {
     static let frameworkResourceBundle: Bundle = {
-        var resourcePath: String?
-
+        let parentBundle: Bundle
 #if LineSDKCocoaPods
-        if let sdkBundlePath = Bundle.frameworkBundle.path(forResource: "LineSDK", ofType: "bundle"),
-            let sdkBundle = Bundle(path: sdkBundlePath) {
-            resourcePath = sdkBundle.path(forResource: "Resource", ofType: "bundle")
-        }
+        parentBundle = sdkBundle
 #else
-        resourcePath = frameworkBundle.path(forResource: "Resource", ofType: "bundle")
+        parentBundle = frameworkBundle
 #endif
-
-        guard let path = resourcePath, let bundle = Bundle(path: path) else
+        
+        guard let path = parentBundle.path(forResource: "Resource", ofType: "bundle"),
+            let bundle = Bundle(path: path) else
         {
             Log.fatalError("SDK resource bundle cannot be found, " +
                            "please verify your installation is not corrupted and try to reinstall LineSDK.")
         }
         return bundle
     }()
+
+#if LineSDKCocoaPods
+    static let sdkBundle: Bundle = {
+        guard let path = Bundle.frameworkBundle.path(forResource: "LineSDK", ofType: "bundle"),
+            let bundle = Bundle(path: path) else {
+                Log.fatalError("LineSDK.bundle cannot be found, " +
+                    "please verify your installation is not corrupted and try to reinstall LineSDK.")
+        }
+        return bundle
+    }()
+#endif
 
     static let frameworkBundle: Bundle = {
         return Bundle(for: LoginManager.self)

--- a/LineSDK/LineSDK/Utils/Constant.swift
+++ b/LineSDK/LineSDK/Utils/Constant.swift
@@ -57,8 +57,18 @@ public struct Constant {
 
 extension Bundle {
     static let frameworkResourceBundle: Bundle = {
-        guard let path = frameworkBundle.path(forResource: "Resource", ofType: "bundle"),
-            let bundle = Bundle(path: path) else
+        var resourcePath: String?
+
+#if LineSDKCocoaPods
+        if let sdkBundlePath = Bundle.frameworkBundle.path(forResource: "LineSDK", ofType: "bundle"),
+            let sdkBundle = Bundle(path: sdkBundlePath) {
+            resourcePath = sdkBundle.path(forResource: "Resource", ofType: "bundle")
+        }
+#else
+        resourcePath = frameworkBundle.path(forResource: "Resource", ofType: "bundle")
+#endif
+
+        guard let path = resourcePath, let bundle = Bundle(path: path) else
         {
             Log.fatalError("SDK resource bundle cannot be found, " +
                            "please verify your installation is not corrupted and try to reinstall LineSDK.")

--- a/LineSDK/LineSDK/Utils/Helpers.swift
+++ b/LineSDK/LineSDK/Utils/Helpers.swift
@@ -158,7 +158,13 @@ extension UIImage {
     ///   - name: The image name.
     ///   - trait: The traits associated with the intended environment for the image.
     convenience init?(bundleNamed name: String, compatibleWith trait: UITraitCollection? = nil) {
-        self.init(named: name, in: .frameworkBundle, compatibleWith: trait)
+        let bundle: Bundle
+#if LineSDKCocoaPods
+        bundle = .sdkBundle
+#else
+        bundle = .frameworkBundle
+#endif
+        self.init(named: name, in: bundle, compatibleWith: trait)
     }
 }
 

--- a/LineSDKSwift.podspec
+++ b/LineSDKSwift.podspec
@@ -25,8 +25,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DLineSDKCocoaPods' }
 
   s.subspec "Core" do |sp|
-    sp.source_files  = ["LineSDK/LineSDK/**/*.swift", "LineSDK/LineSDK/LineSDK.h"]
-    sp.resources     = ["LineSDK/LineSDK/Assets.xcassets", "LineSDK/LineSDK/Resource.bundle"]
+    sp.source_files     = ["LineSDK/LineSDK/**/*.swift", "LineSDK/LineSDK/LineSDK.h"]
+    sp.resource_bundles = { 'LineSDK' => ["LineSDK/LineSDK/Assets.xcassets", "LineSDK/LineSDK/Resource.bundle"] }
   end
 
   s.subspec "ObjC" do |sp|


### PR DESCRIPTION
## About
- Based on the suggestion from https://github.com/line/line-sdk-ios-swift/issues/76
- `resource_bundles` is recommended by CocoaPods over `resources`
## Note
- Since LINE SDK is integrated using dynamic framework, resource will be under separated framework, thus we might not have the same duplicated resource in main bundle issues as describe. 
But still `resource_bundles` is a better way.