### PR TITLE
Adopt provider metadata issuer from discovery document when doing token verification

### DIFF
--- a/LineSDK/LineSDK/Crypto/GetDiscoveryDocumentRequest.swift
+++ b/LineSDK/LineSDK/Crypto/GetDiscoveryDocumentRequest.swift
@@ -45,4 +45,9 @@ struct DiscoveryDocument: Decodable {
         case issuer
         case jwksURI = "jwks_uri"
     }
+
+    struct ResolvedProviderMetadata {
+        let issuer: String
+        let jwk: JWK
+    }
 }

--- a/LineSDK/LineSDK/Login/LoginManager.swift
+++ b/LineSDK/LineSDK/Login/LoginManager.swift
@@ -187,7 +187,9 @@ public class LoginManager {
         let group = DispatchGroup()
         
         var profile: UserProfile?
-        var webToken: JWK?
+
+        var expected: DiscoveryDocument.ResolvedProviderMetadata?
+
         // Any possible errors will be held here.
         var errors: [Error] = []
         
@@ -201,7 +203,7 @@ public class LoginManager {
         
         if token.permissions.contains(.openID) {
             getJWK(for: token, in: group) { result in
-                do { webToken = try result.get() }
+                do { expected = try result.get() }
                 catch { errors.append(error) }
             }
         }
@@ -213,9 +215,9 @@ public class LoginManager {
                 return
             }
             
-            if let key = webToken {
+            if let expected = expected {
                 do {
-                    try self.verifyIDToken(token.IDToken!, key: key, process: process, userID: profile?.userID)
+                    try self.verifyIDToken(token.IDToken!, expected: expected, process: process, userID: profile?.userID)
                 } catch {
                     if let cryptoError = error as? CryptoError {
                         completion(.failure(.authorizeFailed(reason: .cryptoError(error: cryptoError))))
@@ -288,7 +290,7 @@ extension LoginManager {
     func getJWK(
         for token: AccessToken,
         in group: DispatchGroup,
-        handler: @escaping (Result<JWK, LineSDKError>) -> Void)
+        handler: @escaping (Result<DiscoveryDocument.ResolvedProviderMetadata, LineSDKError>) -> Void)
     {
         group.enter()
         // We need a valid ID Token existing to continue.
@@ -320,7 +322,7 @@ extension LoginManager {
                             group.leave()
                             return
                         }
-                        handler(.success(key))
+                        handler(.success(DiscoveryDocument.ResolvedProviderMetadata(issuer: document.issuer, jwk: key)))
                         group.leave()
                     case .failure(let err):
                         handler(.failure(err))
@@ -334,12 +336,12 @@ extension LoginManager {
         }
     }
     
-    func verifyIDToken(_ token: JWT, key: JWK, process: LoginProcess, userID: String?) throws {
+    func verifyIDToken(_ token: JWT, expected: DiscoveryDocument.ResolvedProviderMetadata, process: LoginProcess, userID: String?) throws {
         
-        try token.verify(with: key)
+        try token.verify(with: expected.jwk)
         
         let payload = token.payload
-        try payload.verify(keyPath: \.issuer, expected: "https://access.line.me")
+        try payload.verify(keyPath: \.issuer, expected: expected.issuer)
         
         if let userID = userID {
             try payload.verify(keyPath: \.subject, expected: userID)


### PR DESCRIPTION
### About
- When verifying token, get the issuer metadata from open ID discovery document, instead of a fixed value.
- https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata