### PR TITLE
Keep ID Token while refreshing

### DIFF
--- a/LineSDK/LineSDK/Login/Model/AccessToken.swift
+++ b/LineSDK/LineSDK/Login/Model/AccessToken.swift
@@ -109,6 +109,23 @@ public struct AccessToken: Codable, AccessTokenType, Equatable {
         tokenType = try container.decode(String.self, forKey: .tokenType)
     }
 
+    // Internal helper for creating a new token object with current ID Token kept when refreshing.
+    init(token: AccessToken, currentIDTokenRaw: String?) throws {
+        self.value = token.value
+        self.expiresIn = token.expiresIn
+        self.createdAt = token.createdAt
+        self._refreshToken = token._refreshToken
+        self.permissions = token.permissions
+        self.tokenType = token.tokenType
+
+        self.IDTokenRaw = currentIDTokenRaw
+        if let tokenRaw = IDTokenRaw {
+            IDToken = try JWT(text: tokenRaw)
+        } else {
+            IDToken = nil
+        }
+    }
+
     /// :nodoc:
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
@@ -104,6 +104,29 @@ class LoginManagerTests: XCTestCase, ViewControllerCompatibleTest {
         }
         waitForExpectations(timeout: 1, handler: nil)
     }
-    
+
+    func testRefreshNotOverwriteStoredIDToken() {
+
+        let expect = expectation(description: "\(#file)_\(#line)")
+
+        setupTestToken()
+        XCTAssertTrue(LoginManager.shared.isAuthorized)
+        XCTAssertNotNil(AccessTokenStore.shared.current?.IDToken)
+
+        let delegateStub = SessionDelegateStub(
+            stubs: [.init(data: PostRefreshTokenRequest.successData, responseCode: 200)])
+        Session._shared = Session(
+            configuration: LoginConfiguration.shared,
+            delegate: delegateStub
+        )
+
+        API.refreshAccessToken { result in
+            XCTAssertNotNil(AccessTokenStore.shared.current?.IDToken)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
 }
 


### PR DESCRIPTION
In the current version, when a token is refreshed, the stored ID token inside it will be discarded as well. This is due to the received token in refreshing does not contain the open ID field.

The ID token contains some useful information like user ID, display name and email, so we'd like to keep it as long as possible. It gives users a way to get this information in a sync way.