### PR TITLE
Remove source application check due to not supported on iOS 13

### DIFF
--- a/LineSDK/LineSDK/General/LineSDKError.swift
+++ b/LineSDK/LineSDK/General/LineSDKError.swift
@@ -100,7 +100,7 @@ public enum LineSDKError: Error {
     /// - callbackURLSchemeNotMatching: The received `URL` object while opening the app does not match the
     ///                                 defined URL scheme. Code 3005.
     /// - invalidSourceApplication: The source application is invalid and cannot finish the authorization
-    ///                             process. Code 3006.
+    ///                             process. Not in use anymore from LINE SDK 5.2.4. Code 3006.
     /// - malformedRedirectURL: The received `URL` object while opening the app is invalid or does not
     ///                         contain necessary information. Code 3007.
     /// - invalidLineURLResultCode: The received `URL` object while opening the app has an unknown result
@@ -138,7 +138,8 @@ public enum LineSDKError: Error {
         /// The received `URL` object while opening the app does not match the defined URL scheme. Code 3005.
         case callbackURLSchemeNotMatching
         
-        /// The source application is invalid and cannot finish the authorization process. Code 3006.
+        /// The source application is invalid and cannot finish the authorization process.
+        /// Not in use anymore from LINE SDK 5.2.4. Code 3006.
         case invalidSourceApplication
         
         /// The received `URL` object while opening the app is invalid or does not

--- a/LineSDK/LineSDK/Login/LoginConfiguration.swift
+++ b/LineSDK/LineSDK/Login/LoginConfiguration.swift
@@ -83,18 +83,4 @@ struct LoginConfiguration {
         
         return true
     }
-    
-    /// Checks whether the `appID` is on the white list of calling back source app.
-    ///
-    /// - Parameter appID: The app ID of the source app which opens current app by `open(:url:)`.
-    /// - Returns: `true` if `appID` is from a valid auth application.
-    func isValidSourceApplication(appID: String) -> Bool {
-        var validPrefixes = ["jp.naver", "com.apple", "com.linecorp"]
-        if let currentAppID = Bundle.main.bundleIdentifier {
-            validPrefixes.append(currentAppID)
-        }
-        
-        let valid = validPrefixes.contains { appID.hasPrefix($0) }
-        return valid
-    }
 }

--- a/LineSDK/LineSDK/Login/LoginManager.swift
+++ b/LineSDK/LineSDK/Login/LoginManager.swift
@@ -273,8 +273,7 @@ public class LoginManager {
         guard let url = url else { return false }
         guard let currentProcess = currentProcess else { return false }
         
-        let sourceApplication = options[.sourceApplication] as? String
-        return currentProcess.resumeOpenURL(url: url, sourceApplication: sourceApplication)
+        return currentProcess.resumeOpenURL(url: url)
     }
 }
 

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -237,7 +237,7 @@ public class LoginProcess {
         webLoginFlow.start(in: presentingViewController)
     }
     
-    func resumeOpenURL(url: URL, sourceApplication: String?) -> Bool {
+    func resumeOpenURL(url: URL) -> Bool {
         
         let isValidUniversalLinkURL = configuration.isValidUniversalLinkURL(url: url)
         let isValidCustomizeURL = configuration.isValidCustomizeURL(url: url)
@@ -246,15 +246,6 @@ public class LoginProcess {
         {
             invokeFailure(error: LineSDKError.authorizeFailed(reason: .callbackURLSchemeNotMatching))
             return false
-        }
-        
-        // For universal link callback, we can skip source application checking.
-        // Just do it for customize URL scheme.
-        if isValidCustomizeURL {
-            guard let sourceApp = sourceApplication, configuration.isValidSourceApplication(appID: sourceApp) else {
-                invokeFailure(error: LineSDKError.authorizeFailed(reason: .invalidSourceApplication))
-                return false
-            }
         }
         
         // It is the callback url we could handle, so the app switching observer should be invalidated.

--- a/LineSDK/LineSDKTests/Login/LoginConfigurationTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginConfigurationTests.swift
@@ -71,14 +71,4 @@ class LoginConfigurationTests: XCTestCase {
         let result = config.isValidUniversalLinkURL(url: URL(string: "https://example.com")!)
         XCTAssertEqual(result, false)
     }
-    
-    func testValidSourceApplication() {
-        let config = LoginConfiguration(channelID: "123", universalLinkURL: nil)
-        let results = [
-            "jp.naver.line",
-            "com.apple.hello",
-            "com.company.app"
-        ].map(config.isValidSourceApplication)
-        XCTAssertEqual(results, [true, true, false])
-    }
 }

--- a/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
@@ -83,7 +83,7 @@ class LoginManagerTests: XCTestCase, ViewControllerCompatibleTest {
             XCTAssertTrue(LoginManager.shared.isAuthorizing)
             
             let urlString = "\(Constant.thirdPartyAppReturnURL)?code=123&state=\(process.processID)"
-            let handled = process.resumeOpenURL(url: URL(string: urlString)!, sourceApplication: "com.apple.safari")
+            let handled = process.resumeOpenURL(url: URL(string: urlString)!)
             XCTAssertTrue(handled)
         }
         


### PR DESCRIPTION
`.sourceApplication` is not provided anymore on iOS 13 if the destination app and source app not in the same app group. I guess it is for privacy consideration, but it indeed breaks our implementation on source app verification now.

This PR removes the double-check on the source app.