### PR TITLE
Add IDTokenNonce as public var in login result

### DIFF
--- a/LineSDK/LineSDK/Login/LoginManager.swift
+++ b/LineSDK/LineSDK/Login/LoginManager.swift
@@ -241,7 +241,8 @@ public class LoginManager {
                     accessToken: token,
                     permissions: Set(token.permissions),
                     userProfile: profile,
-                    friendshipStatusChanged: response.friendshipStatusChanged)
+                    friendshipStatusChanged: response.friendshipStatusChanged,
+                    IDTokenNonce: process.IDTokenNonce)
             }
             completion(result)
         }
@@ -361,7 +362,7 @@ extension LoginManager {
         let allowedClockSkew: TimeInterval = 5 * 60
         try payload.verify(keyPath: \.expiration, laterThan: now.addingTimeInterval(-allowedClockSkew))
         try payload.verify(keyPath: \.issueAt, earlierThan: now.addingTimeInterval(allowedClockSkew))
-        try payload.verify(keyPath: \.nonce, expected: process.tokenIDNonce!)
+        try payload.verify(keyPath: \.nonce, expected: process.IDTokenNonce!)
     }
 }
 

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -106,8 +106,8 @@ public class LoginProcess {
     /// A UUID string of current process. Used to verify with server `state` response.
     let processID: String
     
-    /// A string used to prevent replay attacks. This value is returned in an ID token.
-    let tokenIDNonce: String?
+    /// A string used to prevent replay attacks. This value will be returned in an ID token.
+    let IDTokenNonce: String?
     
     var otp: OneTimePassword!
     
@@ -129,9 +129,9 @@ public class LoginProcess {
         self.presentingViewController = viewController
         
         if scopes.contains(.openID) {
-            tokenIDNonce = UUID().uuidString
+            IDTokenNonce = UUID().uuidString
         } else {
-            tokenIDNonce = nil
+            IDTokenNonce = nil
         }
     }
     
@@ -147,7 +147,7 @@ public class LoginProcess {
                     scopes: self.scopes,
                     otp: otp,
                     processID: self.processID,
-                    nonce: self.tokenIDNonce,
+                    nonce: self.IDTokenNonce,
                     botPrompt: self.options.botPrompt,
                     preferredWebPageLanguage: self.preferredWebPageLanguage)
                 if self.options.contains(.onlyWebLogin) {

--- a/LineSDK/LineSDK/Login/LoginResult.swift
+++ b/LineSDK/LineSDK/Login/LoginResult.swift
@@ -35,7 +35,9 @@ public struct LoginResult {
     /// `LoginManagerOption` object when the user logs in. For more information, see Linking a bot with your LINE 
     /// Login channel at https://developers.line.me/en/docs/line-login/web/link-a-bot/.
     public let friendshipStatusChanged: Bool?
-
+    /// The `nonce` value when requesting ID Token during login process. Use this value as a parameter when you
+    /// verify the ID Token against with LINE server. This value is `nil` if `.openID` permission is not requested.
+    public let IDTokenNonce: String?
 }
 
 extension LoginResult: Encodable {
@@ -45,6 +47,7 @@ extension LoginResult: Encodable {
         case scope
         case userProfile
         case friendshipStatusChanged
+        case IDTokenNonce
     }
 
     /// :nodoc:
@@ -54,5 +57,6 @@ extension LoginResult: Encodable {
         try container.encodeLoginPermissions(Array(permissions), forKey: .scope)
         try container.encodeIfPresent(userProfile, forKey: .userProfile)
         try container.encodeIfPresent(friendshipStatusChanged, forKey: .friendshipStatusChanged)
+        try container.encodeIfPresent(IDTokenNonce, forKey: .IDTokenNonce)
     }
 }

--- a/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
@@ -72,6 +72,9 @@ class LoginManagerTests: XCTestCase, ViewControllerCompatibleTest {
             
             XCTAssertTrue(LoginManager.shared.isAuthorized)
             XCTAssertFalse(LoginManager.shared.isAuthorizing)
+
+            // IDTokenNonce should be `nil` when `.openID` not required.
+            XCTAssertNil(result.IDTokenNonce)
             
             try! AccessTokenStore.shared.removeCurrentAccessToken()
             expect.fulfill()
@@ -87,6 +90,50 @@ class LoginManagerTests: XCTestCase, ViewControllerCompatibleTest {
             XCTAssertTrue(handled)
         }
         
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testLoginActionWithOpenID() {
+        let expect = expectation(description: "\(#file)_\(#line)")
+
+        XCTAssertFalse(LoginManager.shared.isAuthorized)
+        XCTAssertFalse(LoginManager.shared.isAuthorizing)
+
+        let delegateStub = SessionDelegateStub(stubs: [
+            .init(data: PostOTPRequest.successData, responseCode: 200),
+            .init(data: PostExchangeTokenRequest.successData, responseCode: 200),
+            .init(data: GetUserProfileRequest.successData, responseCode: 200)
+        ])
+        Session._shared = Session(
+            configuration: LoginConfiguration.shared,
+            delegate: delegateStub
+        )
+
+        var process: LoginProcess!
+        process = LoginManager.shared.login(permissions: [.profile, .openID], in: setupViewController()) {
+            loginResult in
+            XCTAssertNotNil(loginResult.value)
+
+            let result = loginResult.value!
+
+            // IDTokenNonce should be `nil` when `.openID` not required.
+            XCTAssertNotNil(result.IDTokenNonce)
+            XCTAssertEqual(result.IDTokenNonce, process!.IDTokenNonce)
+
+            try! AccessTokenStore.shared.removeCurrentAccessToken()
+            expect.fulfill()
+        }!
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+
+            XCTAssertFalse(LoginManager.shared.isAuthorized)
+            XCTAssertTrue(LoginManager.shared.isAuthorizing)
+
+            let urlString = "\(Constant.thirdPartyAppReturnURL)?code=123&state=\(process.processID)"
+            let handled = process.resumeOpenURL(url: URL(string: urlString)!)
+            XCTAssertTrue(handled)
+        }
+
         waitForExpectations(timeout: 1, handler: nil)
     }
     


### PR DESCRIPTION
This provides a way to access the ID Token nonce in the login result. By this, users can verify the ID token against our server with the nonce checking.