### PR TITLE
Use currentProgress to determine tab selection state when scroll view done

### DIFF
--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
@@ -200,7 +200,7 @@ class PageTabView: UIView {
     }
 
     func tabIndex(from progress: CGFloat) -> Int {
-        return min(Int(progress / divider), tabs.count - 1)
+        return min(Int(progress * CGFloat(tabs.count)), tabs.count - 1)
     }
 
     func updateSelectedIndexForCurrentProgress() {

--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
@@ -229,6 +229,13 @@ class PageTabView: UIView {
         underline.setup(centerX: centerX, width: width)
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        reset()
+        updateScrollingProgress(0)
+        layoutIfNeeded()
+    }
+
     func normalizeProgress(_ progress: CGFloat) {
         // UIPageViewController resets the content offset when new page displayed.
         let diff = currentProgress - progress * nextSpacingFactor - currentDiff
@@ -254,7 +261,9 @@ class PageTabView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func resetSpacingFactor() {
+    func reset() {
         nextSpacingFactor = 1.0
+        currentDiff = 0
+        currentProgress = CGFloat(selectedIndex)
     }
 }

--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
@@ -199,7 +199,16 @@ class PageTabView: UIView {
         delegate?.pageTabView(self, didSelectIndex: index)
     }
 
-    // This only update the `selectedIndex` property and update style when neccessary.
+    func tabIndex(from progress: CGFloat) -> Int {
+        let divider = 1.0 / CGFloat(tabs.count)
+        return min(Int(progress / divider), tabs.count - 1)
+    }
+
+    func updateSelectedIndexForCurrentProgress() {
+        updateSelectedIndex(tabIndex(from: currentProgress))
+    }
+
+    // This only update the `selectedIndex` property and update style when necessary.
     func updateSelectedIndex(_ index: Int) {
         selectedIndex = index
 

--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageTabView.swift
@@ -200,7 +200,6 @@ class PageTabView: UIView {
     }
 
     func tabIndex(from progress: CGFloat) -> Int {
-        let divider = 1.0 / CGFloat(tabs.count)
         return min(Int(progress / divider), tabs.count - 1)
     }
 

--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
@@ -100,7 +100,6 @@ class PageViewController: UIViewController {
 
         pageViewController.setViewControllers(initial, direction: .forward, animated: false)
         pageViewController.dataSource = self
-        pageViewController.delegate = self
 
         addChild(pageViewController, to: pageContainerLayout)
     }
@@ -177,21 +176,6 @@ extension PageViewController: UIPageViewControllerDataSource {
     }
 }
 
-extension PageViewController: UIPageViewControllerDelegate {
-    // triggered when manually drag PageViewController to next page animation ended
-    func pageViewController(
-        _ pageViewController: UIPageViewController,
-        didFinishAnimating finished: Bool,
-        previousViewControllers: [UIViewController],
-        transitionCompleted completed: Bool)
-    {
-        guard let index = currentViewControllerIndex else {
-            return
-        }
-        pageTabView.updateSelectedIndex(index)
-    }
-}
-
 extension PageViewController: PageTabViewDelegate {
     func pageTabView(_ pageTabView: PageTabView, didSelectIndex index: Int) {
         let direction: UIPageViewController.NavigationDirection
@@ -210,5 +194,12 @@ extension PageViewController: UIScrollViewDelegate {
     // triggered when programmatically set the index of PageViewController and its animation ended
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         pageTabView.resetSpacingFactor()
+    }
+
+    // In some cases, `pageViewController(_:didFinishAnimating:previousViewControllers:transitionCompleted:)` is not
+    // called correctly by UIKit. To prevent that case, use `updateSelectedIndexForCurrentProgress` from
+    // this delegate method.
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        pageTabView.updateSelectedIndexForCurrentProgress()
     }
 }

--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
@@ -133,12 +133,6 @@ class PageViewController: UIViewController {
         pageTabHeightConstraint?.constant = hidden ? 0 : PageTabView.TabView.Design.height
         view.layoutIfNeeded()
     }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        pageTabView.layoutIfNeeded()
-        pageTabView.updateScrollingProgress(tabProgress)
-    }
 }
 
 extension PageViewController {
@@ -193,7 +187,7 @@ extension PageViewController: PageTabViewDelegate {
 extension PageViewController: UIScrollViewDelegate {
     // triggered when programmatically set the index of PageViewController and its animation ended
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-        pageTabView.resetSpacingFactor()
+        pageTabView.reset()
     }
 
     // In some cases, `pageViewController(_:didFinishAnimating:previousViewControllers:transitionCompleted:)` is not


### PR DESCRIPTION
`UIPageViewController.viewControllers` are not 100% correct when:

* Swipe over a page and bounce back, or
* Interrupt a swipe but swipe again before it is reset to origin.

Ref: http://www.openradar.me/22833651 and https://stackoverflow.com/questions/36853129/uipageviewcontroller-can-return-the-wrong-index

At the same time, `pageViewController(_:didFinishAnimating:previousViewControllers:transitionCompleted:)` is not always called, especially when in the case of "swiping over a page and letting it bounce back". 

In this PR, I tried to fix these two issues. 

1. Instead of using `UIPageViewController.viewControllers`, now we rely on the `currentProgress` to set the tab index.
2. Choose to use `scrollViewDidEndDecelerating` to trigger this tab update.
        