### PR TITLE
Fix scrolling issue when tapping page tab

### DIFF
--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
@@ -179,7 +179,9 @@ extension PageViewController: PageTabViewDelegate {
             assertionFailure("Cannot get current index for page view controller. It should not happen.")
             direction = .forward
         }
-
+        // Prevents any interaction while the page is scrolling when triggered by page tab selecting.
+        pages.forEach { $0.viewController.view.isUserInteractionEnabled = false }
+        view.isUserInteractionEnabled = false
         pageViewController.setViewControllers([pages[index].viewController], direction: direction, animated: true)
     }
 }
@@ -188,6 +190,8 @@ extension PageViewController: UIScrollViewDelegate {
     // triggered when programmatically set the index of PageViewController and its animation ended
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         pageTabView.reset()
+        pages.forEach { $0.viewController.view.isUserInteractionEnabled = true }
+        view.isUserInteractionEnabled = true
     }
 
     // In some cases, `pageViewController(_:didFinishAnimating:previousViewControllers:transitionCompleted:)` is not


### PR DESCRIPTION
When switching tab while tapping the page tab, if you do other UI action (such as bringing search view by tapping the search bar, or stoping the scrolling animation by hold the page view), we may fall to some strange UI states. It is basically a conflicting of the page view controller bugs and the poor UIKit state management.

This PR fixes the case by blocking user interaction when the scrolling animation happens.