### PR TITLE
Fix panel layout warning on iOS 13

### DIFF
--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/TargetSearch/ShareTargetSearchResultViewController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/TargetSearch/ShareTargetSearchResultViewController.swift
@@ -155,9 +155,16 @@ extension ShareTargetSearchResultViewController {
     }
 
     private func handleKeyboardChange(_ keyboardInfo: KeyboardInfo) {
-        // Wait for iOS layout the current vc. It happens when presenting `self`
-        // with a `.formSheet` style in landscape mode.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        if view.window == nil {
+            // Force iOS to layout the current view. Otherwise, a wrong initial layout happens when presenting `self`
+            // with a `.formSheet` style.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                if self.view.window != nil {
+                    self.updatePanelBottomConstraint(keyboardInfo: keyboardInfo)
+                    self.view.layoutIfNeeded()
+                }
+            }
+        } else {
             self.updatePanelBottomConstraint(keyboardInfo: keyboardInfo)
             UIView.animate(withDuration: keyboardInfo.duration) {
                 self.view.layoutIfNeeded()

--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/TargetSearch/ShareTargetSearchResultViewController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/TargetSearch/ShareTargetSearchResultViewController.swift
@@ -48,6 +48,8 @@ class ShareTargetSearchResultViewController: UIViewController {
     private var panelBottomConstraint: NSLayoutConstraint?
     private var panelHeightConstraint: NSLayoutConstraint?
 
+    private var temporaryKeyboardInfo: KeyboardInfo?
+
     deinit {
         // https://bugs.swift.org/browse/SR-5752
         if #available(iOS 11.0, *) {} else {
@@ -155,30 +157,29 @@ extension ShareTargetSearchResultViewController {
     }
 
     private func handleKeyboardChange(_ keyboardInfo: KeyboardInfo) {
-        if view.window == nil {
-            // Force iOS to layout the current view. Otherwise, a wrong initial layout happens when presenting `self`
-            // with a `.formSheet` style.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                if self.view.window != nil {
-                    self.updatePanelBottomConstraint(keyboardInfo: keyboardInfo)
-                    self.view.layoutIfNeeded()
-                }
-            }
-        } else {
-            self.updatePanelBottomConstraint(keyboardInfo: keyboardInfo)
-            UIView.animate(withDuration: keyboardInfo.duration) {
-                self.view.layoutIfNeeded()
-            }
+        updatePanelBottomConstraint(keyboardInfo: keyboardInfo)
+        UIView.animate(withDuration: keyboardInfo.duration) {
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        if let keyboardInfo = temporaryKeyboardInfo {
+            handleKeyboardChange(keyboardInfo)
+            temporaryKeyboardInfo = nil
         }
     }
 }
 
 extension ShareTargetSearchResultViewController: KeyboardObservable {
     func keyboardInfoWillChange(keyboardInfo: KeyboardInfo) {
-        if !isViewLoaded {
-            // Force load view to make initial layout
-            _ = view
+        // `self.view` is not yet added to current view hierarchy.
+        if view.window == nil {
+            // Wait for iOS to layout the current view. Otherwise, a wrong initial layout happens when presenting `self`
+            // with a `.formSheet` style.
+            temporaryKeyboardInfo = keyboardInfo
+        } else {
+            handleKeyboardChange(keyboardInfo)
         }
-        handleKeyboardChange(keyboardInfo)
     }
 }


### PR DESCRIPTION
On iOS 13, when layout the tableview while it is not yet in the view hierarchy, a runtime warning will be given. This PR delayed the view layout (for selection panel) to `viewDidLayoutSubviews`, to avoid the warning.

At the same time, it would be better to use system method instead of a hard coded duration to wait for system view layout done.