### PR TITLE
Enable user interface when no decelerate happens

### DIFF
--- a/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/SharingUI/PageViewController/PageViewController.swift
@@ -212,6 +212,15 @@ extension PageViewController: UIScrollViewDelegate {
         setUserInteractionEnabled(false)
     }
 
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        // In some cases, dragging will not trigger a deceleration.
+        // So we need to set interaction enabled immediately.
+        // If `willDecelerate`, it is handled in `scrollViewDidEndDecelerating`
+        if !decelerate {
+            setUserInteractionEnabled(true)
+        }
+    }
+
     private func setUserInteractionEnabled(_ enabled: Bool) {
         pages.forEach { $0.viewController.view.isUserInteractionEnabled = enabled }
         view.isUserInteractionEnabled = enabled


### PR DESCRIPTION
Fix a rare case which may freeze the UI when `decelerate` is `false` when stopping dragging in the page view. This happens randomly when you scroll the page in a very small distance.