### PR TITLE
Remove everything codecov

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,6 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-changelog (0.15.0)
-    fastlane-plugin-codecov_reporter (0.1.2)
     ffi (1.12.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -245,9 +244,8 @@ DEPENDENCIES
   cocoapods
   fastlane
   fastlane-plugin-changelog
-  fastlane-plugin-codecov_reporter
   jazzy
   xcode-install
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <img src="https://raw.githubusercontent.com/line/line-sdk-ios-swift/assets/assets/sdklogo.png" width="355" height="97">
 
 [![Build Status](https://travis-ci.org/line/line-sdk-ios-swift.svg?branch=master)](https://travis-ci.org/line/line-sdk-ios-swift)
-[![codecov](https://codecov.io/gh/line/line-sdk-ios-swift/branch/master/graph/badge.svg)](https://codecov.io/gh/line/line-sdk-ios-swift)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/LineSDKSwift.svg)](https://cocoapods.org/pods/LineSDKSwift)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,3 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-changelog'
-gem 'fastlane-plugin-codecov_reporter'


### PR DESCRIPTION
As #59 was merged a year ago, and there's [no more new coverage report](https://codecov.io/gh/line/line-sdk-ios-swift) sent to Codecov, this PR further cleans up Codecov leftovers.