### PR TITLE
Update header navigation links

### DIFF
--- a/jazzy-templates/linedevdocs/templates/header.mustache
+++ b/jazzy-templates/linedevdocs/templates/header.mustache
@@ -1,19 +1,15 @@
 <header class="header">
   <div class="header-left">
     <div>
-      <a class="header-link" href="https://developers.line.biz/en/reference/">
+      <a class="header-link" href="https://developers.line.biz/en/reference/ios-sdk-swift/">
         <span class="header-title">LINE SDK Docs</span>
       </a>
       {{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}
     </div>
     <nav class="GlobalHeaderNav">
       <ul>
-        <li><a class="GlobalHeaderNavLink" href="/en/services/" data-navlink="services" data-translate="translate_header_menu_service">Products</a></li>
-        <li><a class="GlobalHeaderNavLink" href="/en/docs/" data-navlink="docs" data-translate="translate_header_menu_documents">Documents</a></li>
-        <li><a class="GlobalHeaderNavLink" href="/en/news/" data-navlink="news" data-translate="translate_header_menu_news">News</a></li>
-        <li><a class="GlobalHeaderNavLink" href="/en/faq/" data-navlink="faq" data-translate="translate_header_menu_faq">FAQ</a></li>
-        <li><a class="GlobalHeaderNavLink Link-blank" href="https://www.line-community.me/" target="_blank" data-translate="translate_header_menu_community">Community</a></li>
-        <li><a class="GlobalHeaderNavLink Link-blank" href="https://engineering.linecorp.com/en/blog" target="_blank" data-translate="translate_header_menu_blog">Blog</a></li>
+        <li><a class="GlobalHeaderNavLink Link-blank" href="/en/" target="_blank" data-navlink="docs_site" data-translate="translate_header_menu_docs_site">LINE Developers Site</a></li>
+        <li><a class="GlobalHeaderNavLink Link-blank" href="https://github.com/line/line-sdk-ios-swift/releases" target="_blank">Releases</a></li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
## Changes

Updated the header navigation:
- Title link _LINE SDK Docs_ now points to [iOS Swift reference top](https://developers.line.biz/en/reference/ios-sdk-swift/) (and not [Developers Site references overview](https://developers.line.biz/en/reference/) anymore)
- Header links changed to _LINE Developers Site_ and _github releases page_

![Screen Shot 2020-10-21 at 14 15 36](https://user-images.githubusercontent.com/7602082/96676680-dc83f100-13a8-11eb-92ba-e206ed4de53e.png)
