### PR TITLE
`scanHexInt32` API deprecated

### DIFF
--- a/LineSDK/LineSDK.xcodeproj/project.pbxproj
+++ b/LineSDK/LineSDK.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		DB115EF822537F1000C16B0C /* ShareTargetSearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB115EF722537F1000C16B0C /* ShareTargetSearchResultViewController.swift */; };
 		DB115EFA2254660C00C16B0C /* ShareRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB115EF92254660C00C16B0C /* ShareRootViewController.swift */; };
 		DB5035BB22571D3B003CD0B9 /* KeyboardObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5035BA22571D3B003CD0B9 /* KeyboardObservable.swift */; };
+		DB75650928CB254A001A25A5 /* UIColorExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB75650828CB254A001A25A5 /* UIColorExtensionTests.swift */; };
 		DB86931023D5619E0011AEB9 /* PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB86930F23D5619E0011AEB9 /* PKCE.swift */; };
 		DBDCFD322126BD7200E8327A /* GetApproversInFriendsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */; };
 		DBDCFD342126CB6300E8327A /* GetApproversInFriendsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */; };
@@ -889,6 +890,7 @@
 		DB115EF722537F1000C16B0C /* ShareTargetSearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTargetSearchResultViewController.swift; sourceTree = "<group>"; };
 		DB115EF92254660C00C16B0C /* ShareRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareRootViewController.swift; sourceTree = "<group>"; };
 		DB5035BA22571D3B003CD0B9 /* KeyboardObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObservable.swift; sourceTree = "<group>"; };
+		DB75650828CB254A001A25A5 /* UIColorExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensionTests.swift; sourceTree = "<group>"; };
 		DB86930F23D5619E0011AEB9 /* PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCE.swift; sourceTree = "<group>"; };
 		DBDCFD312126BD7200E8327A /* GetApproversInFriendsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsRequest.swift; sourceTree = "<group>"; };
 		DBDCFD332126CB6300E8327A /* GetApproversInFriendsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetApproversInFriendsTests.swift; sourceTree = "<group>"; };
@@ -957,6 +959,7 @@
 			isa = PBXGroup;
 			children = (
 				4B6A0FF8212AACEC00B3ED1F /* HexColorTests.swift */,
+				DB75650828CB254A001A25A5 /* UIColorExtensionTests.swift */,
 				4B15EEFA211D5BF800866E6C /* TextMessageTests.swift */,
 				4B9A3032212111BE00174C6F /* ImageMessageTests.swift */,
 				4B9A303621211CC100174C6F /* VideoMessageTests.swift */,
@@ -2410,6 +2413,7 @@
 				4B39D1E621104F3B00A45510 /* ViewControllerCompatibleTest.swift in Sources */,
 				4BB0E25A239F6BE9008C7F3F /* OpenChatCreatingFormItemTests.swift in Sources */,
 				4BA8E44A210ED82B00355F03 /* AdapterTests.swift in Sources */,
+				DB75650928CB254A001A25A5 /* UIColorExtensionTests.swift in Sources */,
 				4B6A0FF7212AACCF00B3ED1F /* FlexButtonComponentTests.swift in Sources */,
 				DB09851523D5AF9D0001A3B8 /* PKCETests.swift in Sources */,
 				4BBAFC502101D31300E7BFF6 /* ConstantTests.swift in Sources */,

--- a/LineSDK/LineSDK/Utils/Colors.swift
+++ b/LineSDK/LineSDK/Utils/Colors.swift
@@ -136,23 +136,6 @@ extension UIColor {
 
 extension UIColor {
 
-    convenience init(hex3: UInt16, alpha: CGFloat = 1) {
-        let divisor = CGFloat(15)
-        let red     = CGFloat((hex3 & 0xF00) >> 8) / divisor
-        let green   = CGFloat((hex3 & 0x0F0) >> 4) / divisor
-        let blue    = CGFloat( hex3 & 0x00F      ) / divisor
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
-    }
-
-    convenience init(hex4: UInt16) {
-        let divisor = CGFloat(15)
-        let red     = CGFloat((hex4 & 0xF000) >> 12) / divisor
-        let green   = CGFloat((hex4 & 0x0F00) >>  8) / divisor
-        let blue    = CGFloat((hex4 & 0x00F0) >>  4) / divisor
-        let alpha   = CGFloat( hex4 & 0x000F       ) / divisor
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
-    }
-
     convenience init(hex6: UInt32, alpha: CGFloat = 1) {
         let divisor = CGFloat(255)
         let red     = CGFloat((hex6 & 0xFF0000) >> 16) / divisor
@@ -184,8 +167,6 @@ extension UIColor {
             return
         }
         switch (hexString.count) {
-        case 3: self.init(hex3: UInt16(hexValue))
-        case 4: self.init(hex4: UInt16(hexValue))
         case 6: self.init(hex6: hexValue)
         case 8: self.init(hex8: hexValue)
         default: self.init(cgColor: color.cgColor)

--- a/LineSDK/LineSDK/Utils/Colors.swift
+++ b/LineSDK/LineSDK/Utils/Colors.swift
@@ -129,14 +129,14 @@ extension UIColor {
         #endif
     }
 
-    static func compatibleColor(light: UInt32, dark: UInt32) -> UIColor {
+    static func compatibleColor(light: UInt64, dark: UInt64) -> UIColor {
         return compatibleColor(light: .init(hex6: light), dark: .init(hex6: dark))
     }
 }
 
 extension UIColor {
 
-    convenience init(hex6: UInt32, alpha: CGFloat = 1) {
+    convenience init(hex6: UInt64, alpha: CGFloat = 1) {
         let divisor = CGFloat(255)
         let red     = CGFloat((hex6 & 0xFF0000) >> 16) / divisor
         let green   = CGFloat((hex6 & 0x00FF00) >>  8) / divisor
@@ -144,7 +144,7 @@ extension UIColor {
         self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 
-    convenience init(hex8: UInt32) {
+    convenience init(hex8: UInt64) {
         let divisor = CGFloat(255)
         let red     = CGFloat((hex8 & 0xFF000000) >> 24) / divisor
         let green   = CGFloat((hex8 & 0x00FF0000) >> 16) / divisor
@@ -160,9 +160,9 @@ extension UIColor {
         }
 
         let hexString = String(rgb.dropFirst())
-        var hexValue:  UInt32 = 0
+        var hexValue: UInt64 = 0
 
-        guard Scanner(string: hexString).scanHexInt32(&hexValue) else {
+        guard Scanner(string: hexString).scanHexInt64(&hexValue) else {
             self.init(cgColor: color.cgColor)
             return
         }

--- a/LineSDK/LineSDKTests/Message/UIColorExtensionTests.swift
+++ b/LineSDK/LineSDKTests/Message/UIColorExtensionTests.swift
@@ -25,24 +25,24 @@ import XCTest
 class UIColorExtensionTests: XCTestCase {
 
     func testHex6() {
-        let white = UIColor(hex6: 0xFFFFFF, alpha: 1)
+        let white = UIColor(rgb: "#FFFFFF")
         XCTAssertEqual(white.rgbComponents, UIColor.white.rgbComponents)
 
-        let black = UIColor(hex6: 0x000000, alpha: 1)
+        let black = UIColor(rgb: "#000000")
         XCTAssertEqual(black.rgbComponents, UIColor.black.rgbComponents)
 
-        let red = UIColor(hex6: 0xFF0000, alpha: 1)
+        let red = UIColor(rgb: "#FF0000")
         XCTAssertEqual(red.rgbComponents, UIColor.red.rgbComponents)
     }
 
     func testHex8() {
-        let white = UIColor(hex8: 0xFFFFFFFF)
+        let white = UIColor(rgb: "#FFFFFFFF")
         XCTAssertEqual(white.rgbComponents, UIColor.white.rgbComponents)
 
-        let black = UIColor(hex8: 0x000000FF)
+        let black = UIColor(rgb: "#000000FF")
         XCTAssertEqual(black.rgbComponents, UIColor.black.rgbComponents)
 
-        let red = UIColor(hex8: 0xFF0000FF)
+        let red = UIColor(rgb: "#FF0000FF")
         XCTAssertEqual(red.rgbComponents, UIColor.red.rgbComponents)
     }
 }

--- a/LineSDK/LineSDKTests/Message/UIColorExtensionTests.swift
+++ b/LineSDK/LineSDKTests/Message/UIColorExtensionTests.swift
@@ -1,0 +1,54 @@
+//
+//  UIColorExtensionTests.swift
+//
+//  Copyright (c) 2016-present, LINE Corporation. All rights reserved.
+//
+//  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+//  copy and distribute this software in source code or binary form for use
+//  in connection with the web services and APIs provided by LINE Corporation.
+//
+//  As with any software that integrates with the LINE Corporation platform, your use of this software
+//  is subject to the LINE Developers Agreement [http://terms2.line.me/LINE_Developers_Agreement].
+//  This copyright notice shall be included in all copies or substantial portions of the software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import XCTest
+@testable import LineSDK
+
+class UIColorExtensionTests: XCTestCase {
+
+    func testHex6() {
+        let white = UIColor(hex6: 0xFFFFFF, alpha: 1)
+        XCTAssertEqual(white.rgbComponents, UIColor.white.rgbComponents)
+
+        let black = UIColor(hex6: 0x000000, alpha: 1)
+        XCTAssertEqual(black.rgbComponents, UIColor.black.rgbComponents)
+
+        let red = UIColor(hex6: 0xFF0000, alpha: 1)
+        XCTAssertEqual(red.rgbComponents, UIColor.red.rgbComponents)
+    }
+
+    func testHex8() {
+        let white = UIColor(hex8: 0xFFFFFFFF)
+        XCTAssertEqual(white.rgbComponents, UIColor.white.rgbComponents)
+
+        let black = UIColor(hex8: 0x000000FF)
+        XCTAssertEqual(black.rgbComponents, UIColor.black.rgbComponents)
+
+        let red = UIColor(hex8: 0xFF0000FF)
+        XCTAssertEqual(red.rgbComponents, UIColor.red.rgbComponents)
+    }
+}
+
+extension UIColor {
+    var rgbComponents: [CGFloat]? {
+        cgColor.converted(to: CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil)?.components
+    }
+}


### PR DESCRIPTION
## About
- `scanHexInt32` is deprecated at iOS 13, changed to `scanHexInt64`
- add UIColorExtensionTests
- remove internal UIColor extension hex3 and hex4, which are not used in SDK.
## Reference
- [In iOS 11 and later, all apps use the 64-bit architecture.](https://developer.apple.com/documentation/uikit/app_and_environment/updating_your_app_from_32-bit_to_64-bit_architecture) 