### PR TITLE
Update the comment doc for official account terminology change

### DIFF
--- a/LineSDK/LineSDK/Friendship/Request/GetBotFriendshipStatus.swift
+++ b/LineSDK/LineSDK/Friendship/Request/GetBotFriendshipStatus.swift
@@ -21,8 +21,8 @@
 
 import Foundation
 
-/// Represents a request for getting the friendship status of the user and the bot linked to your LINE Login
-/// channel.
+/// Represents a request for getting the friendship status of the user and the LINE Official Account linked to your
+/// LINE Login channel.
 public struct GetBotFriendshipStatusRequest: Request {
     
     /// :nodoc:
@@ -34,11 +34,12 @@ public struct GetBotFriendshipStatusRequest: Request {
     /// :nodoc:
     public init() {}
     
-    /// Represents a response to a request for getting the friendship status of the user and the bot linked to
-    /// your LINE Login channel.
+    /// Represents a response to a request for getting the friendship status of the user and the LINE Official Account
+    /// linked to your LINE Login channel.
     public struct Response: Codable {
-        /// Indicates the friendship status. `true` if the bot is a friend of the user and the user has not
-        /// blocked the bot. `false` if the bot is not a friend of the user or the user has blocked the bot. 
+        /// Indicates the friendship status. `true` if the LINE Official Account is a friend of the user and the user
+        /// has not blocked the LINE Official Account. `false` if the LINE Official Account is not a friend of the user
+        /// or the user has blocked the LINE Official Account.
         public let friendFlag: Bool
     }
 }

--- a/LineSDK/LineSDK/Login/LoginManagerOptions.swift
+++ b/LineSDK/LineSDK/Login/LoginManagerOptions.swift
@@ -45,15 +45,15 @@ public struct LoginManagerOptions: OptionSet {
     
     /// - Warning: Deprecated. Use `LoginManager.Parameters.botPromptStyle` instead.
     ///
-    /// Includes an option to add a bot as friend on the consent screen. If `.botPromptNormal` and
+    /// Includes an option to add a LINE Official Account as friend on the consent screen. If `.botPromptNormal` and
     /// `.botPromptAggressive` are set at the same time, `.botPromptAggressive` will be used.
     @available(*, deprecated, message: "Use `LoginManager.Parameters.botPromptStyle` instead.")
     public static let botPromptNormal = LoginManagerOptions(rawValue: 1 << 1)
     
     /// - Warning: Deprecated. Use `LoginManager.Parameters.botPromptStyle` instead.
     ///
-    /// Opens a new screen to add a bot as a friend after the user agrees to the permissions on the consent
-    /// screen. If `.botPromptNormal` and `.botPromptAggressive` is set at the same time,
+    /// Opens a new screen to add a LINE Official Account as a friend after the user agrees to the permissions on the
+    /// consent screen. If `.botPromptNormal` and `.botPromptAggressive` is set at the same time,
     /// `.botPromptAggressive` will be used.
     @available(*, deprecated, message: "Use `LoginManager.Parameters.botPromptStyle` instead.")
     public static let botPromptAggressive = LoginManagerOptions(rawValue: 1 << 2)

--- a/LineSDK/LineSDK/Login/LoginManagerParameters.swift
+++ b/LineSDK/LineSDK/Login/LoginManagerParameters.swift
@@ -29,7 +29,7 @@ extension LoginManager {
         /// Forces the use of web authentication flow instead of LINE app-to-app authentication flow.
         public var onlyWebLogin: Bool = false
         
-        /// The style for showing the "Add bot as friend" prompt on the consent screen.
+        /// The style for showing the "Add LINE Official Account as friend" prompt on the consent screen.
         public var botPromptStyle: BotPrompt? = nil
         
         /// Sets the preferred language used when logging in with the web authorization flow.
@@ -81,12 +81,12 @@ extension LoginManager {
 
 extension LoginManager {
     
-    /// The style for showing the "Add bot as friend" prompt on the consent screen.
+    /// The style for showing the "Add LINE Official Account as friend" prompt on the consent screen.
     public enum BotPrompt: String {
-        /// Includes an option to add a bot as friend on the consent screen.
+        /// Includes an option to add a LINE Official Account as friend on the consent screen.
         case normal
-        /// Opens a new screen to add a bot as a friend after the user agrees to the permissions on the consent
-        /// screen.
+        /// Opens a new screen to add a LINE Official Account as a friend after the user agrees to the permissions on the
+        /// consent screen.
         case aggressive
     }
     

--- a/LineSDK/LineSDK/Login/LoginResult.swift
+++ b/LineSDK/LineSDK/Login/LoginResult.swift
@@ -30,10 +30,10 @@ public struct LoginResult {
     /// Contains the user profile including the user ID, display name, and so on. The value exists only when the
     /// `.profile` permission is set in the authorization request.
     public let userProfile: UserProfile?
-    /// Indicates that the friendship status between the user and the bot changed during the login. This value is
-    /// non-`nil` only if the `.botPromptNormal` or `.botPromptAggressive` are specified as part of the
-    /// `LoginManagerOption` object when the user logs in. For more information, see Linking a bot with your LINE 
-    /// Login channel at https://developers.line.biz/en/docs/line-login/web/link-a-bot/.
+    /// Indicates that the friendship status between the user and the LINE Official Account changed during the login.
+    /// This value is non-`nil` only if the `.botPromptNormal` or `.botPromptAggressive` are specified as part of the
+    /// `LoginManagerOption` object when the user logs in. For more information, see "Add a LINE Official Account as
+    /// a friend when logged in (bot link)" at https://developers.line.biz/en/docs/line-login/web/link-a-bot/
     public let friendshipStatusChanged: Bool?
     /// The `nonce` value when requesting ID Token during login process. Use this value as a parameter when you
     /// verify the ID Token against the LINE server. This value is `nil` if `.openID` permission is not requested.

--- a/LineSDK/LineSDK/Networking/API/API.swift
+++ b/LineSDK/LineSDK/Networking/API/API.swift
@@ -50,7 +50,7 @@ public enum API {
         Session.shared.send(request, callbackQueue: queue, completionHandler: completion)
     }
     
-    /// Gets the friendship status of the user and the bot linked to your LINE Login channel.
+    /// Gets the friendship status of the user and the LINE Official Account linked to your LINE Login channel.
     ///
     /// - Parameters:
     ///   - queue: The callback queue that is used for `completion`. The default value is

--- a/LineSDKSample/LineSDKSample/API/APIStore.swift
+++ b/LineSDKSample/LineSDKSample/API/APIStore.swift
@@ -106,7 +106,7 @@ extension APIStore {
         
         friendshipAPIs = [
             .init(
-                title: "Get Bot Friendship Status",
+                title: "Get Official Account Friendship Status",
                 request: GetBotFriendshipStatusRequest()
             )
         ]

--- a/LineSDKSample/LineSDKSample/Login/LoginSettingsViewController.swift
+++ b/LineSDKSample/LineSDKSample/Login/LoginSettingsViewController.swift
@@ -74,7 +74,7 @@ class LoginSettingsViewController: UITableViewController {
             }
         ),
         ParameterItem(
-            title: "Bot Prompt",
+            title: "Bot (OA) Prompt",
             text: { p in
                 switch p.botPromptStyle {
                 case .aggressive: return "Aggressive"


### PR DESCRIPTION
We now call the bot as "LINE Official Account". This updates the API reference in doc comment to reflect the change.