### PR TITLE
Sign the xcframework artifacts with distribution cert

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -162,6 +162,7 @@ platform :ios do
       include_debug_symbols: true,
       xcframework_output_directory: output_path
     )
+    Actions.sh("codesign --timestamp -v --sign 'Apple Distribution: LINE Corporation (VUTU7AKEUR)' ../#{output_path}/LineSDK.xcframework")
     artifact_paths.push(ENV["XCFRAMEWORK_OUTPUT_PATH"])
     
     create_xcframework(
@@ -172,6 +173,7 @@ platform :ios do
       include_debug_symbols: true,
       xcframework_output_directory: output_path
     )
+    Actions.sh("codesign --timestamp -v --sign 'Apple Distribution: LINE Corporation (VUTU7AKEUR)' ../#{output_path}/LineSDKObjC.xcframework")
     artifact_paths.push(ENV["XCFRAMEWORK_OUTPUT_PATH"])
 
     zipped_files = []

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -162,7 +162,9 @@ platform :ios do
       include_debug_symbols: true,
       xcframework_output_directory: output_path
     )
-    Actions.sh("codesign --timestamp -v --sign 'Apple Distribution: LINE Corporation (VUTU7AKEUR)' ../#{output_path}/LineSDK.xcframework")
+    unless is_ci
+      Actions.sh("codesign --timestamp -v --sign 'Apple Distribution: LINE Corporation (VUTU7AKEUR)' ../#{output_path}/LineSDK.xcframework")
+    end
     artifact_paths.push(ENV["XCFRAMEWORK_OUTPUT_PATH"])
     
     create_xcframework(
@@ -173,7 +175,9 @@ platform :ios do
       include_debug_symbols: true,
       xcframework_output_directory: output_path
     )
-    Actions.sh("codesign --timestamp -v --sign 'Apple Distribution: LINE Corporation (VUTU7AKEUR)' ../#{output_path}/LineSDKObjC.xcframework")
+    unless is_ci
+      Actions.sh("codesign --timestamp -v --sign 'Apple Distribution: LINE Corporation (VUTU7AKEUR)' ../#{output_path}/LineSDKObjC.xcframework")
+    end
     artifact_paths.push(ENV["XCFRAMEWORK_OUTPUT_PATH"])
 
     zipped_files = []


### PR DESCRIPTION
As verified as below:

<img width="358" alt="截屏2023-10-31 11 59 15" src="https://github.com/line/line-sdk-ios-swift/assets/1019875/6d114562-4c56-40dd-bbdf-0c1e8c907108">

For now, we only support exporting the xcframework locally from the releasing machine. Maybe later we can find a CI node to run the release script and allow the cert be read from the host.

But as the first step, we now sign it when releasing and it follows [the session](https://developer.apple.com/videos/play/wwdc2023/10061/) and allows users to verify our product.