### PR TITLE
Explicitly disable bitcode

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -159,6 +159,7 @@ platform :ios do
       workspace: "LineSDK.xcworkspace", 
       scheme: "LineSDK", 
       destinations: ['iOS'],
+      enable_bitcode: false,
       include_debug_symbols: true,
       xcframework_output_directory: output_path
     )
@@ -172,6 +173,7 @@ platform :ios do
       scheme: "LineSDKObjCBinary", 
       product_name: "LineSDKObjC", 
       destinations: ['iOS'], 
+      enable_bitcode: false,
       include_debug_symbols: true,
       xcframework_output_directory: output_path
     )


### PR DESCRIPTION
This fixes #209 

The script we are using to create the xcframework is using `true` as the default value for bit code. We need to pass in the `false` to disable this behavior.