### PR TITLE
Add a parameter for setting `initial_amr_display`

### DIFF
--- a/LineSDK/LineSDK/Login/LoginManagerParameters.swift
+++ b/LineSDK/LineSDK/Login/LoginManagerParameters.swift
@@ -52,7 +52,12 @@ extension LoginManager {
         /// generate a random value as the token nonce. Whether set or not, LINE SDK verifies against the nonce value
         /// in received ID token locally.
         public var IDTokenNonce: String? = nil
-        
+
+        /// Sets the `initial_amr_display` used when logging in with the web authorization flow.
+        ///
+        /// If set to `lineqr`, "Log in with QR code“ will be displayed by default instead of Log in with email address.
+        public var initialAMRDisplay: String? = nil
+
         /// Determines whether it's possible to create another login process while the original one is still valid.
         /// If `true`, when a new login action is started, any existing one ends with a
         /// `GeneralErrorReason.processDiscarded` error. If `false`, the new login action is ignored, and the

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -402,7 +402,7 @@ class WebLoginFlow: NSObject {
     
     init(parameter: LoginProcess.FlowParameters) {
         let webLoginURLBase = URL(string: Constant.lineWebAuthURL)!
-         url = webLoginURLBase.appendedLoginQuery(parameter)
+        url = webLoginURLBase.appendedLoginQuery(parameter)
     }
     
     func start(in viewController: UIViewController?) {

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -45,10 +45,21 @@ public class LoginProcess {
         let pkce: PKCE
         let processID: String
         let nonce: String?
-        let botPrompt: LoginManager.BotPrompt?
-        let preferredWebPageLanguage: LoginManager.WebPageLanguage?
-        let onlyWebLogin: Bool
-        let promptBotID: String?
+
+        let loginParameter: LoginManager.Parameters
+
+        var botPrompt: LoginManager.BotPrompt? {
+            loginParameter.botPromptStyle
+        }
+        var preferredWebPageLanguage: LoginManager.WebPageLanguage? {
+            loginParameter.preferredWebPageLanguage
+        }
+        var onlyWebLogin: Bool {
+            loginParameter.onlyWebLogin
+        }
+        var promptBotID: String? {
+            loginParameter.promptBotID
+        }
     }
     
     /// Observes application switching to foreground.
@@ -177,10 +188,7 @@ public class LoginProcess {
             pkce: pkce,
             processID: processID,
             nonce: IDTokenNonce,
-            botPrompt: parameters.botPromptStyle,
-            preferredWebPageLanguage: parameters.preferredWebPageLanguage,
-            onlyWebLogin: parameters.onlyWebLogin,
-            promptBotID: parameters.promptBotID
+            loginParameter: parameters
         )
         #if targetEnvironment(macCatalyst)
         // On macCatalyst, we only support web login

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -480,6 +480,9 @@ extension String {
         if let promptBotID = parameter.promptBotID {
             parameters["prompt_bot_id"] = promptBotID
         }
+        if let initialAMRDisplay = parameter.loginParameter.initialAMRDisplay {
+            parameters["initial_amr_display"] = initialAMRDisplay
+        }
         let base = URL(string: "/oauth2/v2.1/authorize/consent")!
         let encoder = URLQueryEncoder(parameters: parameters)
         return encoder.encoded(for: base).absoluteString

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -467,9 +467,6 @@ extension String {
         if let promptBotID = parameter.loginParameter.promptBotID {
             parameters["prompt_bot_id"] = promptBotID
         }
-        if let initialAMRDisplay = parameter.loginParameter.initialAMRDisplay {
-            parameters["initial_amr_display"] = initialAMRDisplay
-        }
         let base = URL(string: "/oauth2/v2.1/authorize/consent")!
         let encoder = URLQueryEncoder(parameters: parameters)
         return encoder.encoded(for: base).absoluteString
@@ -488,6 +485,9 @@ extension URL {
         }
         if flowParameters.loginParameter.onlyWebLogin {
             parameters["disable_ios_auto_login"] = true
+        }
+        if let initialAMRDisplay = flowParameters.loginParameter.initialAMRDisplay {
+            parameters["initial_amr_display"] = initialAMRDisplay
         }
 
         let encoder = URLQueryEncoder(parameters: parameters)

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -47,19 +47,6 @@ public class LoginProcess {
         let nonce: String?
 
         let loginParameter: LoginManager.Parameters
-
-        var botPrompt: LoginManager.BotPrompt? {
-            loginParameter.botPromptStyle
-        }
-        var preferredWebPageLanguage: LoginManager.WebPageLanguage? {
-            loginParameter.preferredWebPageLanguage
-        }
-        var onlyWebLogin: Bool {
-            loginParameter.onlyWebLogin
-        }
-        var promptBotID: String? {
-            loginParameter.promptBotID
-        }
     }
     
     /// Observes application switching to foreground.
@@ -194,7 +181,7 @@ public class LoginProcess {
         // On macCatalyst, we only support web login
         startWebLoginFlow(parameters)
         #else
-        if parameters.onlyWebLogin {
+        if parameters.loginParameter.onlyWebLogin {
             startWebLoginFlow(parameters)
         } else {
             startAppUniversalLinkFlow(parameters)
@@ -474,10 +461,10 @@ extension String {
         if let nonce = parameter.nonce {
             parameters["nonce"] = nonce
         }
-        if let botPrompt = parameter.botPrompt {
+        if let botPrompt = parameter.loginParameter.botPromptStyle {
             parameters["bot_prompt"] = botPrompt.rawValue
         }
-        if let promptBotID = parameter.promptBotID {
+        if let promptBotID = parameter.loginParameter.promptBotID {
             parameters["prompt_bot_id"] = promptBotID
         }
         if let initialAMRDisplay = parameter.loginParameter.initialAMRDisplay {
@@ -496,10 +483,10 @@ extension URL {
             "returnUri": returnUri,
             "loginChannelId": flowParameters.channelID
         ]
-        if let lang = flowParameters.preferredWebPageLanguage {
+        if let lang = flowParameters.loginParameter.preferredWebPageLanguage {
             parameters["ui_locales"] = lang.rawValue
         }
-        if flowParameters.onlyWebLogin {
+        if flowParameters.loginParameter.onlyWebLogin {
             parameters["disable_ios_auto_login"] = true
         }
 

--- a/LineSDK/LineSDKObjC/Login/LineSDKLoginManagerParameters.swift
+++ b/LineSDK/LineSDKObjC/Login/LineSDKLoginManagerParameters.swift
@@ -54,6 +54,11 @@ public class LineSDKLoginManagerParameters: NSObject {
         get { return _value.IDTokenNonce }
         set { _value.IDTokenNonce = newValue }
     }
+
+    public var initialAMRDisplay: String? {
+        get { return _value.initialAMRDisplay }
+        set { _value.initialAMRDisplay = newValue }
+    }
 }
 
 @objcMembers

--- a/LineSDK/LineSDKObjCInterfaceTests/LineSDKModelInterfaceTests.m
+++ b/LineSDK/LineSDKObjCInterfaceTests/LineSDKModelInterfaceTests.m
@@ -104,11 +104,13 @@
     param.preferredWebPageLanguage = @"ja";
     param.IDTokenNonce = @"test";
     param.promptBotID = @"@abc123";
-    
+    param.initialAMRDisplay = @"lineqr";
+
     XCTAssertTrue([param onlyWebLogin]);
     XCTAssertTrue([[param.botPromptStyle rawValue] isEqualToString: @"normal"]);
     XCTAssertTrue([param.preferredWebPageLanguage isEqualToString: @"ja"]);
     XCTAssertTrue([param.IDTokenNonce isEqualToString: @"test"]);
+    XCTAssertTrue([param.initialAMRDisplay isEqualToString:@"lineqr"]);
 }
 
 - (void)testLoginResultInterface {

--- a/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
@@ -84,7 +84,22 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
             return p
         }()
     )
-    
+
+    let parameterWithInitialAMRDisplay = LoginProcess.FlowParameters(
+        channelID: "123",
+        universalLinkURL: nil,
+        scopes: [.profile, .openID],
+        pkce: PKCE(),
+        processID: "abc",
+        nonce: "kkk",
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            p.initialAMRDisplay = "lineqr"
+            return p
+        }()
+    )
+
     // Login URL has a double escaped query.
     func testLoginQueryURLEncode() {
         
@@ -178,7 +193,21 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         XCTAssertNotEqual(item.value, item.value?.removingPercentEncoding)
         XCTAssertTrue(item.value!.removingPercentEncoding!.contains("prompt_bot_id=@abc123"))
     }
-    
+
+    func testLoginQueryWithInitialAMRDisplay() {
+        let baseURL = URL(string: Constant.lineWebAuthUniversalURL)!
+        let result = baseURL.appendedLoginQuery(parameterWithInitialAMRDisplay)
+
+        let urlString = result.absoluteString.removingPercentEncoding
+        XCTAssertNotNil(urlString)
+
+        let components = URLComponents(url: result, resolvingAgainstBaseURL: false)
+        let items = components!.queryItems!
+        XCTAssertEqual(items.count, ["loginChannelId", "returnUri", "initial_amr_display"].count)
+        let item = items.first { $0.name == "initial_amr_display" }!
+        XCTAssertEqual(item.value, "lineqr")
+    }
+
     // URL Scheme has a triple escaped query.
     func testURLSchemeQueryEncode() {
         let baseURL = Constant.lineAppAuthURLv2

--- a/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
@@ -33,10 +33,11 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: false,
-        promptBotID: nil
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            return p
+        }()
     )
 
     let parameterWithLanguage = LoginProcess.FlowParameters(
@@ -46,10 +47,12 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: .chineseSimplified,
-        onlyWebLogin: false,
-        promptBotID: nil
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            p.preferredWebPageLanguage = .chineseSimplified
+            return p
+        }()
     )
 
     let parameterWithOnlyWebLogin = LoginProcess.FlowParameters(
@@ -59,10 +62,12 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: true,
-        promptBotID: nil
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            p.onlyWebLogin = true
+            return p
+        }()
     )
 
     let parameterWithPromptBotID = LoginProcess.FlowParameters(
@@ -72,10 +77,12 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: false,
-        promptBotID: "@abc123"
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            p.promptBotID = "@abc123"
+            return p
+        }()
     )
     
     // Login URL has a double escaped query.

--- a/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
@@ -113,17 +113,17 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         let items = components!.queryItems!
         XCTAssertEqual(items.count, ["loginChannelId", "returnUri"].count)
         
-        var item: URLQueryItem
+        var item: URLQueryItem?
 
-        item = items.first { $0.name == "loginChannelId" }!
-        XCTAssertEqual(item.value, "123")
+        item = items.first { $0.name == "loginChannelId" }
+        XCTAssertEqual(item?.value, "123")
 
-        item = items.first { $0.name == "returnUri" }!
-        XCTAssertNotEqual(item.value, item.value?.removingPercentEncoding)
+        item = items.first { $0.name == "returnUri" }
+        XCTAssertNotEqual(item?.value, item?.value?.removingPercentEncoding)
 
         // Should be already fully decoded (no double encoding in the url)
-        XCTAssertEqual(item.value?.removingPercentEncoding,
-                       item.value?.removingPercentEncoding?.removingPercentEncoding)
+        XCTAssertEqual(item?.value?.removingPercentEncoding,
+                       item?.value?.removingPercentEncoding?.removingPercentEncoding)
     }
 
     func testLoginQueryWithLangURLEncode() {
@@ -166,16 +166,16 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         let items = components!.queryItems!
         XCTAssertEqual(items.count, ["loginChannelId", "returnUri", "disable_ios_auto_login"].count)
 
-        var item: URLQueryItem
+        var item: URLQueryItem?
 
-        item = items.first { $0.name == "loginChannelId" }!
-        XCTAssertEqual(item.value, "123")
+        item = items.first { $0.name == "loginChannelId" }
+        XCTAssertEqual(item?.value, "123")
 
-        item = items.first { $0.name == "returnUri" }!
-        XCTAssertNotEqual(item.value, item.value?.removingPercentEncoding)
+        item = items.first { $0.name == "returnUri" }
+        XCTAssertNotEqual(item?.value, item?.value?.removingPercentEncoding)
 
-        item = items.first { $0.name == "disable_ios_auto_login" }!
-        XCTAssertEqual(item.value, "true")
+        item = items.first { $0.name == "disable_ios_auto_login" }
+        XCTAssertEqual(item?.value, "true")
     }
 
     func testLoginQueryWithPromptBotID() {
@@ -189,9 +189,9 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         let items = components!.queryItems!
         XCTAssertEqual(items.count, ["loginChannelId", "returnUri"].count)
 
-        let item = items.first { $0.name == "returnUri" }!
-        XCTAssertNotEqual(item.value, item.value?.removingPercentEncoding)
-        XCTAssertTrue(item.value!.removingPercentEncoding!.contains("prompt_bot_id=@abc123"))
+        let item = items.first { $0.name == "returnUri" }
+        XCTAssertNotEqual(item?.value, item?.value?.removingPercentEncoding)
+        XCTAssertTrue(item?.value?.removingPercentEncoding?.contains("prompt_bot_id=@abc123") == true)
     }
 
     func testLoginQueryWithInitialAMRDisplay() {
@@ -204,8 +204,8 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         let components = URLComponents(url: result, resolvingAgainstBaseURL: false)
         let items = components!.queryItems!
         XCTAssertEqual(items.count, ["loginChannelId", "returnUri", "initial_amr_display"].count)
-        let item = items.first { $0.name == "initial_amr_display" }!
-        XCTAssertEqual(item.value, "lineqr")
+        let item = items.first { $0.name == "initial_amr_display" }
+        XCTAssertEqual(item?.value, "lineqr")
     }
 
     // URL Scheme has a triple escaped query.
@@ -220,14 +220,14 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         let items = components!.queryItems!
         XCTAssertEqual(items.count, ["loginChannelId"].count)
 
-        let item = items.first { $0.name == "loginUrl" }!
-        XCTAssertNotEqual(item.value, item.value?.removingPercentEncoding)
-        XCTAssertNotEqual(item.value?.removingPercentEncoding,
-                          item.value?.removingPercentEncoding?.removingPercentEncoding)
+        let item = items.first { $0.name == "loginUrl" }
+        XCTAssertNotEqual(item?.value, item?.value?.removingPercentEncoding)
+        XCTAssertNotEqual(item?.value?.removingPercentEncoding,
+                          item?.value?.removingPercentEncoding?.removingPercentEncoding)
 
         // Should be already fully decoded (no double encoding in the url)
-        XCTAssertEqual(item.value?.removingPercentEncoding?.removingPercentEncoding,
-                       item.value?.removingPercentEncoding?.removingPercentEncoding?.removingPercentEncoding)
+        XCTAssertEqual(item?.value?.removingPercentEncoding?.removingPercentEncoding,
+                       item?.value?.removingPercentEncoding?.removingPercentEncoding?.removingPercentEncoding)
     }
     
     func testAppUniversalLinkFlow() {

--- a/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
@@ -29,10 +29,7 @@ let sampleFlowParameters = LoginProcess.FlowParameters(
         pkce: .init(),
         processID: "",
         nonce: nil,
-        botPrompt: nil,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: false,
-        promptBotID: nil
+        loginParameter: .init()
 )
 
 class LoginManagerTests: XCTestCase, ViewControllerCompatibleTest {

--- a/LineSDKSample/LineSDKSample/Login/LoginSettingsViewController.swift
+++ b/LineSDKSample/LineSDKSample/Login/LoginSettingsViewController.swift
@@ -88,6 +88,18 @@ class LoginSettingsViewController: UITableViewController {
                 case .none: p.botPromptStyle = .aggressive
                 }
             }
+        ),
+        ParameterItem(
+            title: "Initial AMR",
+            text: { p in
+                return p.initialAMRDisplay ?? "None"
+            }, action: { p in
+                if p.initialAMRDisplay == nil {
+                    p.initialAMRDisplay = "lineqr"
+                } else {
+                    p.initialAMRDisplay = nil
+                }
+            }
         )
     ]
 
@@ -137,6 +149,7 @@ class LoginSettingsViewController: UITableViewController {
             let p = parameters[indexPath.row]
             cell.textLabel?.text = p.title
             cell.detailTextLabel?.text = p.text(loginSettings.parameters)
+            cell.accessoryType = .none
         }
 
         return cell


### PR DESCRIPTION
Add a login parameter to allow users set the `initial_amr_display` value.

Also some refactoring for better internal API is contained.

See the documentation for more detail: https://developers.line.biz/en/docs/line-login/integrate-line-login/