### PR TITLE
Add a parameter for setting `initialWebAuthenticationMethod`

### DIFF
--- a/LineSDK/LineSDK/Login/LoginManagerParameters.swift
+++ b/LineSDK/LineSDK/Login/LoginManagerParameters.swift
@@ -63,6 +63,11 @@ extension LoginManager {
         #else
         public var allowRecreatingLoginProcess = false
         #endif
+
+        /// Specifies the initial web authentication method to be used when starting the login process.
+        /// 
+        /// By default, `.email` is used to provide input boxes for email and password.
+        public var initialWebAuthenticationMethod: WebAuthenticationMethod = .email
         
         /// Creates a default `LoginManager.Parameters` value.
         public init() {}
@@ -89,7 +94,13 @@ extension LoginManager {
         /// consent screen.
         case aggressive
     }
-    
+
+    /// The method used for the authentication when using the web authentication flow.
+    public enum WebAuthenticationMethod: String {
+        case email
+        case qrCode
+    }
+
     /// Represents the language used in the web page.
     public struct WebPageLanguage {
         /// :nodoc:

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -45,10 +45,21 @@ public class LoginProcess {
         let pkce: PKCE
         let processID: String
         let nonce: String?
-        let botPrompt: LoginManager.BotPrompt?
-        let preferredWebPageLanguage: LoginManager.WebPageLanguage?
-        let onlyWebLogin: Bool
-        let promptBotID: String?
+
+        let loginParameter: LoginManager.Parameters
+
+        var botPrompt: LoginManager.BotPrompt? {
+            loginParameter.botPromptStyle
+        }
+        var preferredWebPageLanguage: LoginManager.WebPageLanguage? {
+            loginParameter.preferredWebPageLanguage
+        }
+        var onlyWebLogin: Bool {
+            loginParameter.onlyWebLogin
+        }
+        var promptBotID: String? {
+            loginParameter.promptBotID
+        }
     }
     
     /// Observes application switching to foreground.
@@ -177,10 +188,7 @@ public class LoginProcess {
             pkce: pkce,
             processID: processID,
             nonce: IDTokenNonce,
-            botPrompt: parameters.botPromptStyle,
-            preferredWebPageLanguage: parameters.preferredWebPageLanguage,
-            onlyWebLogin: parameters.onlyWebLogin,
-            promptBotID: parameters.promptBotID
+            loginParameter: parameters
         )
         #if targetEnvironment(macCatalyst)
         // On macCatalyst, we only support web login

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -414,8 +414,15 @@ class WebLoginFlow: NSObject {
     weak var safariViewController: UIViewController?
     
     init(parameter: LoginProcess.FlowParameters) {
-        let webLoginURLBase = URL(string: Constant.lineWebAuthURL)!
-         url = webLoginURLBase.appendedLoginQuery(parameter)
+        var component = URLComponents(string: Constant.lineWebAuthURL)!
+        if parameter.loginParameter.initialWebAuthenticationMethod == .qrCode {
+            if let _ = component.fragment {
+                assertionFailure("Multiple fragment is not yet supported. Require review or report to developer.")
+            }
+            component.fragment = "/qr"
+        }
+        let baseURL = component.url!
+        url = baseURL.appendedLoginQuery(parameter)
     }
     
     func start(in viewController: UIViewController?) {

--- a/LineSDK/LineSDKObjC/Login/LineSDKLoginManagerParameters.swift
+++ b/LineSDK/LineSDKObjC/Login/LineSDKLoginManagerParameters.swift
@@ -44,12 +44,17 @@ public class LineSDKLoginManagerParameters: NSObject {
         get { return _value.promptBotID }
         set { _value.promptBotID = newValue }
     }
-    
+
+    public var initialWebAuthenticationMethod: LineSDKLoginManagerWebAuthenticationMethod {
+        get { return LineSDKLoginManagerWebAuthenticationMethod(_value.initialWebAuthenticationMethod) }
+        set { _value.initialWebAuthenticationMethod = newValue._value }
+    }
+
     public var preferredWebPageLanguage: String? {
         get { return _value.preferredWebPageLanguage?.rawValue }
         set { _value.preferredWebPageLanguage = newValue.map { .init(rawValue: $0) } }
     }
-    
+
     public var IDTokenNonce: String? {
         get { return _value.IDTokenNonce }
         set { _value.IDTokenNonce = newValue }
@@ -65,5 +70,17 @@ public class LineSDKLoginManagerBotPrompt: NSObject {
     public static let normal = LineSDKLoginManagerBotPrompt(.normal)
     public static let aggressive = LineSDKLoginManagerBotPrompt(.aggressive)
     
+    public var rawValue: String { return _value.rawValue }
+}
+
+@objcMembers
+public class LineSDKLoginManagerWebAuthenticationMethod: NSObject {
+
+    let _value: LoginManager.WebAuthenticationMethod
+    init(_ value: LoginManager.WebAuthenticationMethod) { _value = value }
+
+    public static let email = LineSDKLoginManagerWebAuthenticationMethod(.email)
+    public static let qrCode = LineSDKLoginManagerWebAuthenticationMethod(.qrCode)
+
     public var rawValue: String { return _value.rawValue }
 }

--- a/LineSDK/LineSDKObjCInterfaceTests/LineSDKModelInterfaceTests.m
+++ b/LineSDK/LineSDKObjCInterfaceTests/LineSDKModelInterfaceTests.m
@@ -104,11 +104,13 @@
     param.preferredWebPageLanguage = @"ja";
     param.IDTokenNonce = @"test";
     param.promptBotID = @"@abc123";
-    
+    param.initialWebAuthenticationMethod = [LineSDKLoginManagerWebAuthenticationMethod qrCode];
+
     XCTAssertTrue([param onlyWebLogin]);
     XCTAssertTrue([[param.botPromptStyle rawValue] isEqualToString: @"normal"]);
     XCTAssertTrue([param.preferredWebPageLanguage isEqualToString: @"ja"]);
     XCTAssertTrue([param.IDTokenNonce isEqualToString: @"test"]);
+    XCTAssertTrue([[param.initialWebAuthenticationMethod rawValue] isEqualToString:@"qrCode"]);
 }
 
 - (void)testLoginResultInterface {

--- a/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginFlowTests.swift
@@ -33,10 +33,11 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: false,
-        promptBotID: nil
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            return p
+        }()
     )
 
     let parameterWithLanguage = LoginProcess.FlowParameters(
@@ -46,10 +47,12 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: .chineseSimplified,
-        onlyWebLogin: false,
-        promptBotID: nil
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            p.preferredWebPageLanguage = .chineseSimplified
+            return p
+        }()
     )
 
     let parameterWithOnlyWebLogin = LoginProcess.FlowParameters(
@@ -59,10 +62,12 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: true,
-        promptBotID: nil
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            p.onlyWebLogin = true
+            return p
+        }()
     )
 
     let parameterWithPromptBotID = LoginProcess.FlowParameters(
@@ -72,10 +77,12 @@ class LoginFlowTests: XCTestCase, ViewControllerCompatibleTest {
         pkce: PKCE(),
         processID: "abc",
         nonce: "kkk",
-        botPrompt: .normal,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: false,
-        promptBotID: "@abc123"
+        loginParameter: {
+            var p = LoginManager.Parameters()
+            p.botPromptStyle = .normal
+            p.promptBotID = "@abc123"
+            return p
+        }()
     )
     
     // Login URL has a double escaped query.

--- a/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
+++ b/LineSDK/LineSDKTests/Login/LoginManagerTests.swift
@@ -29,10 +29,7 @@ let sampleFlowParameters = LoginProcess.FlowParameters(
         pkce: .init(),
         processID: "",
         nonce: nil,
-        botPrompt: nil,
-        preferredWebPageLanguage: nil,
-        onlyWebLogin: false,
-        promptBotID: nil
+        loginParameter: .init()
 )
 
 class LoginManagerTests: XCTestCase, ViewControllerCompatibleTest {

--- a/LineSDKSample/LineSDKSample/Login/LoginSettingsViewController.swift
+++ b/LineSDKSample/LineSDKSample/Login/LoginSettingsViewController.swift
@@ -88,6 +88,20 @@ class LoginSettingsViewController: UITableViewController {
                 case .none: p.botPromptStyle = .aggressive
                 }
             }
+        ),
+        ParameterItem(
+            title: "Initial Auth Method",
+            text: { p in
+                switch p.initialWebAuthenticationMethod {
+                case .email: return "Email"
+                case .qrCode: return "QR Code"
+                }
+            }, action: { p in
+                switch p.initialWebAuthenticationMethod {
+                case .email: p.initialWebAuthenticationMethod = .qrCode
+                case .qrCode: p.initialWebAuthenticationMethod = .email
+                }
+            }
         )
     ]
 
@@ -137,6 +151,7 @@ class LoginSettingsViewController: UITableViewController {
             let p = parameters[indexPath.row]
             cell.textLabel?.text = p.title
             cell.detailTextLabel?.text = p.text(loginSettings.parameters)
+            cell.accessoryType = .none
         }
 
         return cell


### PR DESCRIPTION
Use this setting, users can specify which auth method (email&password or QR code) should be preferred as the first screen when performing web login.

Sample usage:

```swift
var parameters = LoginManager.Parameters()
parameters.initialWebAuthenticationMethod = .qrCode
LoginManager.shared.login(parameters: parameters) { result in
    // Handle result.
}
```

By default, `.email` is used to keep the current behavior unchanged.

Also some refactoring of internal affairs, to make the interface more stable in future when we need to add more login parameters.