### PR TITLE
Add test coverage badge and HTML report generation

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,74 @@
+name: Coverage Badge
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  coverage:
+    name: Update Coverage Badge
+    runs-on: macos-15
+    environment: "Coverage Badge Env"  # Use specified GitHub environment
+    
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Cache Gems
+        uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+            
+      - name: Bundle Install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+          
+      - name: Run Tests with Coverage
+        env:
+          SWIFT_VERSION: "6.0"
+        run: bundle exec fastlane sdk_tests_with_coverage
+        
+      - name: Extract Coverage
+        id: coverage
+        run: |
+          ruby script/extract_coverage.rb
+          
+      - name: Update Coverage Badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.GIST_ID }}
+          filename: line-sdk-ios-coverage.json
+          label: Coverage
+          message: ${{ steps.coverage.outputs.coverage }}
+          color: ${{ steps.coverage.outputs.color }}
+          
+      - name: Deploy Coverage Report to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./coverage_output
+          publish_branch: gh-pages
+          enable_jekyll: false
+          allow_empty_commit: false
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy coverage report for ${{ github.sha }}'
+          
+      - name: Upload Coverage Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            ./coverage_output/
+            ./test_output/
+          retention-days: 30

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "fastlane"
 gem "jazzy"
 gem "xcode-install"
 gem "cocoapods"
+gem "xcov"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
+    slack-notifier (2.4.0)
     sqlite3 (1.7.3-arm64-darwin)
     sysrandom (1.0.5)
     terminal-notifier (2.0.0)
@@ -310,10 +311,18 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.4.0)
       rexml (>= 3.3.6, < 4.0)
+    xcov (1.8.1)
+      fastlane (>= 2.141.0, < 3.0.0)
+      multipart-post
+      slack-notifier
+      terminal-table
+      xcodeproj
+      xcresult (~> 0.2.0)
     xcpretty (0.4.1)
       rouge (~> 3.28.0)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
+    xcresult (0.2.2)
 
 PLATFORMS
   arm64-darwin-22
@@ -326,6 +335,7 @@ DEPENDENCIES
   fastlane-plugin-create_xcframework
   jazzy
   xcode-install
+  xcov
 
 BUNDLED WITH
    2.3.26

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://raw.githubusercontent.com/line/line-sdk-ios-swift/assets/assets/sdklogo.png" width="355" height="97">
 
 [![LINE SDK CI](https://github.com/line/line-sdk-ios-swift/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/line/line-sdk-ios-swift/actions/workflows/ci.yaml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/onevcat/49ddb455d585b4c0599186552cfb0249/raw/line-sdk-ios-coverage.json)](https://line.github.io/line-sdk-ios-swift/)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/LineSDKSwift.svg)](https://cocoapods.org/pods/LineSDKSwift)
 [![Swift Package Manager Compatible](https://img.shields.io/badge/SPM-supported-DE5C43.svg?style=flat)](https://swift.org/package-manager/)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,6 +37,34 @@ platform :ios do
     )
   end
 
+  desc "Run tests with coverage reporting"
+  lane :sdk_tests_with_coverage do
+    swift_version = ENV["SWIFT_VERSION"] || "6.0"
+    
+    # Run tests with code coverage enabled
+    run_tests(
+        workspace: "LineSDK.xcworkspace",
+        devices: ["iPhone 16"],
+        scheme: "LineSDK",
+        xcargs: "SWIFT_VERSION=#{swift_version}",
+        code_coverage: true,
+        output_directory: "./test_output",
+        result_bundle: true
+    )
+    
+    # Generate coverage reports using xcov
+    xcov(
+        workspace: "LineSDK.xcworkspace",
+        scheme: "LineSDK",
+        output_directory: "./coverage_output",
+        html_report: true,
+        json_report: true,
+        minimum_coverage_percentage: 0.0,
+        include_test_targets: false,
+        skip_slack: true
+    )
+  end
+
   lane :sample_tests do
     # Ensure required environment variables are set
     unless ENV["LINE_SDK_TEST_EMAIL"] && ENV["LINE_SDK_TEST_PASSWORD"]

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -39,6 +39,14 @@ Run tests.
 
 
 
+### ios sdk_tests_with_coverage
+
+```sh
+[bundle exec] fastlane ios sdk_tests_with_coverage
+```
+
+Run tests with coverage reporting
+
 ### ios sample_tests
 
 ```sh

--- a/script/extract_coverage.rb
+++ b/script/extract_coverage.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+require 'json'
+
+# Read coverage report from xcov
+coverage_file = './coverage_output/report.json'
+
+if File.exist?(coverage_file)
+  begin
+    data = JSON.parse(File.read(coverage_file))
+    
+    # Extract overall coverage percentage
+    coverage_percentage = data['coverage'] ? (data['coverage'] * 100).round(1) : 0.0
+    
+    # Determine badge color based on coverage
+    color = case coverage_percentage
+            when 0...60 then 'red'
+            when 60...80 then 'yellow'  
+            when 80..100 then 'green'
+            else 'lightgrey'
+            end
+    
+    puts "Coverage: #{coverage_percentage}%"
+    puts "Color: #{color}"
+    
+    # Output for GitHub Actions
+    puts "::set-output name=coverage::#{coverage_percentage}%"
+    puts "::set-output name=color::#{color}"
+    
+    # Save coverage for reference
+    File.write('coverage.txt', "#{coverage_percentage}%")
+    
+  rescue JSON::ParserError => e
+    puts "Error parsing coverage report: #{e.message}"
+    puts "::set-output name=coverage::unknown"
+    puts "::set-output name=color::lightgrey"
+    File.write('coverage.txt', "unknown")
+  end
+else
+  puts "Coverage report not found at: #{coverage_file}"
+  puts "::set-output name=coverage::unknown"
+  puts "::set-output name=color::lightgrey"
+  File.write('coverage.txt', "unknown")
+end


### PR DESCRIPTION
## Summary
- Add test coverage badge to README.md for better project visibility
- Implement HTML test coverage report generation for detailed analysis
- Add new GitHub workflow for coverage reporting

## Test plan
- [x] Verify coverage badge displays correctly in README
- [x] Ensure coverage workflow runs successfully in CI
- [x] Confirm HTML report generation works properly
- [x] Test coverage calculation accuracy