### PR TITLE
Do not trigger coverage CI when PR

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,8 +3,6 @@ name: Coverage Badge
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   coverage:


### PR DESCRIPTION
This skip the coverage workflow when PR. It reduces some resource usage since we only want to update the coverage badge for master.