### PR TITLE
Add presentingAnimation parameter to OpenChatCreatingController

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ jobs:
     name: Test LINE SDK
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
         swift-version: ["6.0", "5.0", "4.2"]
     steps:
@@ -29,6 +30,7 @@ jobs:
     name: Lint CocoaPods
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
         swift-version: ["6.0", "5.0", "4.2"]
     steps:

--- a/LineSDK/LineSDK/LineSDKUI/OpenChatUI/Public/OpenChatCreatingController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/OpenChatUI/Public/OpenChatCreatingController.swift
@@ -91,6 +91,7 @@ public class OpenChatCreatingController {
     /// ```
     public func loadAndPresent(
         in viewController: UIViewController,
+        presentingAnimation: Bool = true,
         navigationDismissAnimating: Bool = true,
         presentedHandler handler: ((Result<UIViewController, LineSDKError>) -> Void)? = nil
     )
@@ -102,6 +103,7 @@ public class OpenChatCreatingController {
                 if response.agreed {
                     self.presentCreatingViewController(
                         in: viewController,
+                        presentingAnimation: presentingAnimation,
                         navigationDismissAnimating: navigationDismissAnimating,
                         handler: handler
                     )
@@ -149,6 +151,7 @@ public class OpenChatCreatingController {
     
     func presentCreatingViewController(
         in viewController: UIViewController,
+        presentingAnimation: Bool = true,
         navigationDismissAnimating: Bool = true,
         handler: ((Result<UIViewController, LineSDKError>) -> Void)?
     )
@@ -198,13 +201,13 @@ public class OpenChatCreatingController {
                 }
             }
             
-            navigation.pushViewController(userInfoFormViewController, animated: true)
+            navigation.pushViewController(userInfoFormViewController, animated: presentingAnimation)
         }
         
         navigation.modalPresentationStyle = .fullScreen
         
         delegate?.openChatCreatingController(self, willPresentCreatingNavigationController: navigation)
-        viewController.present(navigation, animated: true) { handler?(.success(navigation)) }
+        viewController.present(navigation, animated: presentingAnimation) { handler?(.success(navigation)) }
     }
 }
 

--- a/LineSDK/LineSDKTests/OpenChat/OpenChatControllerTests.swift
+++ b/LineSDK/LineSDKTests/OpenChat/OpenChatControllerTests.swift
@@ -115,7 +115,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let controller = OpenChatCreatingController()
         
         // Test loadAndPresent flow when terms not agreed
-        controller.loadAndPresent(in: viewController, navigationDismissAnimating: false) { result in
+        controller.loadAndPresent(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             switch result {
             case .success(let resultVC):
                 XCTAssertNotNil(viewController.presentedViewController)
@@ -151,7 +155,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let viewController = setupViewController()
         
         let controller = OpenChatCreatingController()
-        controller.loadAndPresent(in: viewController, navigationDismissAnimating: false) { result in
+        controller.loadAndPresent(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             expect.fulfill()
             switch result {
             case .success:
@@ -178,7 +186,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let mockDelegate = MockOpenChatCreatingControllerDelegate()
         controller.delegate = mockDelegate
         
-        controller.presentCreatingViewController(in: viewController, navigationDismissAnimating: false) { result in
+        controller.presentCreatingViewController(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             switch result {
             case .success(let navigationVC):
                 XCTAssertNotNil(viewController.presentedViewController)
@@ -228,7 +240,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let mockDelegate = MockOpenChatCreatingControllerDelegate()
         controller.delegate = mockDelegate
         
-        controller.presentCreatingViewController(in: viewController, navigationDismissAnimating: false) { result in
+        controller.presentCreatingViewController(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             switch result {
             case .success(let navigationVC):
                 guard let navigation = navigationVC as? UINavigationController,
@@ -280,7 +296,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let mockDelegate = MockOpenChatCreatingControllerDelegate()
         controller.delegate = mockDelegate
         
-        controller.presentCreatingViewController(in: viewController, navigationDismissAnimating: false) { result in
+        controller.presentCreatingViewController(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             switch result {
             case .success(let navigationVC):
                 guard let navigation = navigationVC as? UINavigationController,
@@ -333,7 +353,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let mockDelegate = MockOpenChatCreatingControllerDelegate()
         controller.delegate = mockDelegate
         
-        controller.presentCreatingViewController(in: viewController, navigationDismissAnimating: false) { result in
+        controller.presentCreatingViewController(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             switch result {
             case .success(let navigationVC):
                 guard let navigation = navigationVC as? UINavigationController,
@@ -395,7 +419,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         controller.delegate = mockDelegate
         
         // Start the load and present operation
-        controller.loadAndPresent(in: viewController, navigationDismissAnimating: false) { result in
+        controller.loadAndPresent(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             // This should not be called when delegate prevents the alert
             XCTFail("Handler should not be called when delegate prevents alert")
         }
@@ -425,7 +453,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let viewController = setupViewController()
         let controller = OpenChatCreatingController()
         
-        controller.loadAndPresent(in: viewController, navigationDismissAnimating: false) { result in
+        controller.loadAndPresent(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             expect.fulfill()
             switch result {
             case .success:
@@ -447,7 +479,11 @@ class OpenChatCreatingControllerTests: XCTestCase, ViewControllerCompatibleTest 
         let mockDelegate = MockOpenChatCreatingControllerDelegate()
         controller.delegate = mockDelegate
         
-        controller.presentCreatingViewController(in: viewController, navigationDismissAnimating: false) { result in
+        controller.presentCreatingViewController(
+            in: viewController,
+            presentingAnimation: false,
+            navigationDismissAnimating: false
+        ) { result in
             expect.fulfill()
             switch result {
             case .success:


### PR DESCRIPTION
## Summary
- Add `presentingAnimation` parameter to `loadAndPresent` and `presentCreatingViewController` methods in `OpenChatCreatingController`
- Allow controlling animation for both view controller presentation and navigation controller push operations
- Update all unit tests to use `presentingAnimation: false` to improve test reliability and reduce timing issues

## Changes
- Added optional `presentingAnimation: Bool = true` parameter to maintain backward compatibility
- Applied animation control to both `present(_:animated:completion:)` and `pushViewController(_:animated:)` calls
- Updated all test cases in `OpenChatControllerTests.swift` to explicitly disable animations during testing

## Test plan
- [x] All existing unit tests pass
- [x] SDK tests run successfully with `bundle exec fastlane sdk_tests`
- [x] Backward compatibility maintained with default `true` value
- [x] Animation control works for both presentation and navigation operations