### PR TITLE
Fix iOS 15 API warnings

### DIFF
--- a/LineSDK/LineSDK/LineSDKUI/LoginButton.swift
+++ b/LineSDK/LineSDK/LineSDKUI/LoginButton.swift
@@ -205,20 +205,25 @@ open class LoginButton: UIButton {
             setBackgroundImage(UIImage(bundleNamed: imageName), for: state)
         }
 
-        titleEdgeInsets = UIEdgeInsets(
-            top:    CGFloat(buttonSize.constant.bubbleWidth / 2),
-            left:   CGFloat(buttonSize.constant.iconWidth +
-                            buttonSize.constant.separatorWidth +
-                            buttonSize.constant.leftPadding),
-            bottom: CGFloat(buttonSize.constant.bubbleWidth / 2),
-            right:  CGFloat(buttonSize.constant.rightPadding)
-        )
-        
         setTitle(buttonText, for: .normal)
         
         let titleSize = titleLabel?.intrinsicContentSize ?? .zero
         frame.size = buttonSize.sizeForTitleSize(titleSize)
         invalidateIntrinsicContentSize()
+    }
+
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+
+        let constant = buttonSize.constant
+        let titleLeading = CGFloat(constant.iconWidth + constant.separatorWidth + constant.leftPadding)
+        let titleVerticalInset = CGFloat(constant.bubbleWidth / 2)
+        titleLabel?.frame = CGRect(
+            x: titleLeading,
+            y: titleVerticalInset,
+            width: bounds.width - titleLeading - CGFloat(constant.rightPadding),
+            height: bounds.height - titleVerticalInset * 2
+        )
     }
 
     /// Overrides the getter of the `intrinsicContentSize` property to support automatic layout.

--- a/LineSDK/LineSDK/LineSDKUI/OpenChatUI/Model/FormEntry.swift
+++ b/LineSDK/LineSDK/LineSDKUI/OpenChatUI/Model/FormEntry.swift
@@ -74,7 +74,7 @@ class RoomDescriptionText: FormEntry {
     }
 }
 
-class Option<T: CustomStringConvertible & Equatable>: FormEntry {
+class Option<T: CustomStringConvertible & Equatable & Sendable>: FormEntry {
     var selectedOption: T {
         didSet {
             cell.detailTextLabel?.text = selectedOption.description

--- a/LineSDK/LineSDK/LineSDKUI/OpenChatUI/View/CountLimitedTextView.swift
+++ b/LineSDK/LineSDK/LineSDKUI/OpenChatUI/View/CountLimitedTextView.swift
@@ -21,6 +21,8 @@
 
 import UIKit
 
+private let clearButtonContentInsets = NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)
+
 protocol CountLimitedTextViewStyle {
     var font: UIFont { get }
     var textColor: UIColor { get }
@@ -101,8 +103,10 @@ class CountLimitedTextView: UIView {
     
     private(set) lazy var clearButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
-        button.setImage(UIImage(bundleNamed: "setting_icon_delete_normal"), for: .normal)
+        var configuration = UIButton.Configuration.plain()
+        configuration.contentInsets = clearButtonContentInsets
+        configuration.image = UIImage(bundleNamed: "setting_icon_delete_normal")
+        button.configuration = configuration
         button.isHidden = true
         button.addTarget(self, action: #selector(clearText), for: .touchUpInside)
         return button
@@ -174,7 +178,7 @@ class CountLimitedTextView: UIView {
         NSLayoutConstraint.activate([
             clearButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             clearButton.trailingAnchor
-                .constraint(equalTo: trailingAnchor, constant: -13 + clearButton.contentEdgeInsets.right)
+                .constraint(equalTo: trailingAnchor, constant: -13 + clearButtonContentInsets.trailing)
         ])
         
         // Placeholder

--- a/LineSDK/LineSDK/LineSDKUI/OpenChatUI/ViewControllers/OptionSelectingViewController.swift
+++ b/LineSDK/LineSDK/LineSDKUI/OpenChatUI/ViewControllers/OptionSelectingViewController.swift
@@ -21,7 +21,7 @@
 
 import UIKit
 
-class OptionSelectingViewController<T: CustomStringConvertible & Equatable>: UITableViewController {
+class OptionSelectingViewController<T: CustomStringConvertible & Equatable & Sendable>: UITableViewController {
     
     let onSelected = Delegate<T, Void>()
     

--- a/LineSDK/LineSDK/Login/LoginProcess.swift
+++ b/LineSDK/LineSDK/Login/LoginProcess.swift
@@ -595,15 +595,20 @@ extension URL {
 
 extension UIWindow {
     static func findKeyWindow() -> UIWindow? {
-        if let window = (UIApplication.shared.windows.filter {$0.isKeyWindow}.first), window.windowLevel == .normal {
+        let windowScenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+        let windows = windowScenes.flatMap(\.windows)
+
+        if let window = windows.first(where: { $0.isKeyWindow && $0.windowLevel == .normal }) {
             // A key window of main app exists, go ahead and use it
             return window
         }
 
         // Otherwise, try to find a normal level window
-        let window = UIApplication.shared.windows.first { $0.windowLevel == .normal }
+        let window = windows.first { $0.windowLevel == .normal }
         guard let result = window else {
-            Log.print("Cannot find a valid UIWindow at normal level. Current windows: \(UIApplication.shared.windows)")
+            Log.print("Cannot find a valid UIWindow at normal level. Current windows: \(windows)")
             return nil
         }
         return result

--- a/LineSDK/LineSDK/OpenChat/Model/OpenChatCategory.swift
+++ b/LineSDK/LineSDK/OpenChat/Model/OpenChatCategory.swift
@@ -22,7 +22,7 @@
 import Foundation
 
 /// Represents the category of an Open Chat room.
-public enum OpenChatCategory: Int, CaseIterable {
+public enum OpenChatCategory: Int, CaseIterable, Sendable {
     // The order is important. It is the order which displayed when using `OpenChatCategory.allCases`.
     /// Not selected.
     case notSelected = 1

--- a/LineSDK/LineSDKTests/LoginButtonTests.swift
+++ b/LineSDK/LineSDKTests/LoginButtonTests.swift
@@ -164,15 +164,24 @@ class LoginButtonTests: XCTestCase, ViewControllerCompatibleTest {
     
     // MARK: - UI Configuration Tests
     
-    func testTitleEdgeInsets() {
+    func testTitleLayout() {
         loginButton.buttonSize = .normal
         loginButton.updateButtonStyle()
-        
-        let insets = loginButton.titleEdgeInsets
-        XCTAssertTrue(insets.left > 0)
-        XCTAssertTrue(insets.right > 0)
-        XCTAssertTrue(insets.top > 0)
-        XCTAssertTrue(insets.bottom > 0)
+        loginButton.frame.size = loginButton.intrinsicContentSize
+        loginButton.layoutIfNeeded()
+
+        let constant = loginButton.buttonSize.constant
+        let titleLeading = CGFloat(constant.iconWidth + constant.separatorWidth + constant.leftPadding)
+        let titleVerticalInset = CGFloat(constant.bubbleWidth / 2)
+        XCTAssertEqual(
+            loginButton.titleLabel?.frame,
+            CGRect(
+                x: titleLeading,
+                y: titleVerticalInset,
+                width: loginButton.bounds.width - titleLeading - CGFloat(constant.rightPadding),
+                height: loginButton.bounds.height - titleVerticalInset * 2
+            )
+        )
     }
     
     func testBackgroundImages() {

--- a/LineSDKSample/LineSDKSample/Utils/IndicatorDisplay.swift
+++ b/LineSDKSample/LineSDKSample/Utils/IndicatorDisplay.swift
@@ -34,7 +34,6 @@ extension IndicatorDisplay where Self: UIViewController {
     }
 
     func showIndicatorOnWindow() {
-        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
         showIndicator(in: keyWindow ?? view)
     }
     
@@ -43,8 +42,11 @@ extension IndicatorDisplay where Self: UIViewController {
     }
 
     func hideIndicatorFromWindow() {
-        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
         hideIndicator(from: keyWindow ?? view)
+    }
+
+    private var keyWindow: UIWindow? {
+        view.window?.windowScene?.windows.first { $0.isKeyWindow }
     }
     
     func showIndicator(in view: UIView) {


### PR DESCRIPTION
## Summary
- migrate the Open Chat clear button to `UIButton.Configuration`
- lay out the login button title explicitly, preserving its existing background assets and intrinsic size without deprecated edge insets
- select login and Sample indicator windows from the relevant `UIWindowScene`
- require `Sendable` option values for Swift isolated conformance safety

## Validation
- `LineSDK` clean build for iOS Simulator
- `LineSDK` test build for iOS Simulator
- `LineSDKObjC` clean build for iOS Simulator
- `LineSDKObjCBinary` clean build for iOS Simulator
- `IndicatorDisplay.swift` typecheck for iOS Simulator
